### PR TITLE
Add ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ venv
 
 # Doxygen output
 docs/html/
+
+# Testing output
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: python
+python:
+    - "2.6"
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "nightly"
+install: pip install tox-travis
+script: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ nose
 flake8
 pydocstyle
 pylint
+tox
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (https://testrun.org/tox/latest/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py32, py33, py34, py35, py36, pypy, pypy3, jython
+skip_missing_interpreters=True
+
+[testenv]
+deps = nose
+commands =
+	nosetests


### PR DESCRIPTION
I think this should work, but you should know that running tox locally I found an error with:

```
====================================================================
ERROR: Failure: ModuleNotFoundError (No module named 'dag')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/lee1001/projs/llnl/maestrowf/.tox/py36/lib/python3.6/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/Users/lee1001/projs/llnl/maestrowf/.tox/py36/lib/python3.6/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/lee1001/projs/llnl/maestrowf/.tox/py36/lib/python3.6/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/lee1001/projs/llnl/maestrowf/.tox/py36/lib/python3.6/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/lee1001/projs/llnl/maestrowf/.tox/py36/lib/python3.6/imp.py", line 244, in load_module
    return load_package(name, filename)
  File "/Users/lee1001/projs/llnl/maestrowf/.tox/py36/lib/python3.6/imp.py", line 216, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 675, in _load
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "/Users/lee1001/projs/llnl/maestrowf/maestrowf/interfaces/__init__.py", line 32, in <module>
    from maestrowf.interfaces.script.slurmscriptadapter import SlurmScriptAdapter
  File "/Users/lee1001/projs/llnl/maestrowf/maestrowf/interfaces/script/slurmscriptadapter.py", line 38, in <module>
    from maestrowf.datastructures.core import State
  File "/Users/lee1001/projs/llnl/maestrowf/maestrowf/datastructures/__init__.py", line 43, in <module>
    from dag import DAG
ModuleNotFoundError: No module named 'dag'
```

Closes #22 when merged