### PR TITLE
Ability to Create Linear Studies without Parameters

### DIFF
--- a/maestrowf/datastructures/core/parameters.py
+++ b/maestrowf/datastructures/core/parameters.py
@@ -263,6 +263,17 @@ class ParameterGenerator(SimObject):
         """
         return self.get_combinations()
 
+    def __bool__(self):
+        """
+        Override for the __bool__ operator.
+
+        :returns: True if the ParameterGenerator instance has values, False
+        otherwise.
+        """
+        return bool(self.parameters)
+
+    __nonzero__ = __bool__
+
     def get_combinations(self):
         """
         Generate all combinations of parameters.

--- a/maestrowf/datastructures/core/studyenvironment.py
+++ b/maestrowf/datastructures/core/studyenvironment.py
@@ -60,6 +60,15 @@ class StudyEnvironment(SimObject):
 
         logger.debug("Initialized an empty StudyEnvironment.")
 
+    def __bool__(self):
+        """
+        Override for the __bool__ operator.
+
+        :returns: True if the StudyEnvironment instance has values, False
+        otherwise.
+        """
+        return bool(self._names)
+
     @property
     def is_set_up(self):
         """


### PR DESCRIPTION
All studies currently need parameters. This PR adds a feature that allows for a specification to not include a set of parameters which creates a strictly linear, one time execution, study.