### PR TITLE
Minor tweaks for capturing integers in the environment.

### DIFF
--- a/maestrowf/datastructures/core/studyenvironment.py
+++ b/maestrowf/datastructures/core/studyenvironment.py
@@ -100,7 +100,9 @@ class StudyEnvironment(SimObject):
             logger.debug("Tokens: %s", self._tokens)
             name = item.name
             logger.debug("Adding %s of type %s.", item.name, type(item))
-            if any(token in item.value for token in self._tokens):
+            if (
+                    isinstance(item.value, str) and
+                    any(token in item.value for token in self._tokens)):
                 logger.debug("Label detected. Adding %s to labels", item.name)
                 self.labels[item.name] = item
             else:

--- a/maestrowf/datastructures/environment/variable.py
+++ b/maestrowf/datastructures/environment/variable.py
@@ -86,8 +86,8 @@ class Variable(Substitution):
         self._verification("Attempting to substitute a variable that is not"
                            " complete.")
         logger.debug("%s: %s", self.get_var(),
-                     data.replace(self.get_var(), self.value))
-        return data.replace(self.get_var(), self.value)
+                     data.replace(self.get_var(), str(self.value)))
+        return data.replace(self.get_var(), str(self.value))
 
     def _verify(self):
         """


### PR DESCRIPTION
This PR addresses the issue in #32. The bug was just a small issue where the StudyEnvironment was not accounting for the possibility of getting an integer. The fix was simple:
* Check that a substitution is a string and that it has a variable token in it. If so, it's a label. If it's not a string or it doesn't have the token, treat it as a straight replacement.
* The Variable class now has to cast the value to a string for substitutions.