### PR TITLE
Correct logger.warning call in localscriptadapter

### DIFF
--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -135,5 +135,5 @@ class LocalScriptAdapter(ScriptAdapter):
             LOGGER.info("Execution returned status OK.")
             return SubmissionCode.OK, pid
         else:
-            LOGGER.warning("Execution returned an error: {}", str(err))
+            LOGGER.warning("Execution returned an error: %s", str(err))
             return SubmissionCode.ERROR, pid


### PR DESCRIPTION
logger.warning uses % to perform string formatting. % does
not support new style string formatting with {}.