### PR TITLE
Implementation of study cancellation

### DIFF
--- a/maestrowf/abstracts/enums/__init__.py
+++ b/maestrowf/abstracts/enums/__init__.py
@@ -38,6 +38,11 @@ class SubmissionCode(Enum):
     ERROR = 1
 
 
+class CancelCode(Enum):
+    OK = 0
+    ERROR = 1
+
+
 class JobStatusCode(Enum):
     OK = 0
     NOJOBS = 1
@@ -59,3 +64,4 @@ class State(Enum):
     HWFAILURE = 9
     TIMEDOUT = 10
     UNKNOWN = 11
+    CANCELLED = 12

--- a/maestrowf/abstracts/interfaces/scriptadapter.py
+++ b/maestrowf/abstracts/interfaces/scriptadapter.py
@@ -65,6 +65,16 @@ class ScriptAdapter(object):
         pass
 
     @abstractmethod
+    def cancel_jobs(self, joblist):
+        """
+        For the given job list, cancel each job.
+
+        :param joblist: A list of job identifiers to be cancelled.
+        :returns: The return code to indicate if jobs were cancelled.
+        """
+        pass
+
+    @abstractmethod
     def _write_script(self, ws_path, step):
         """
         Write a script to the workspace of a workflow step.

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -32,7 +32,8 @@ import logging
 import os
 from subprocess import PIPE, Popen
 
-from maestrowf.abstracts.enums import JobStatusCode, SubmissionCode
+from maestrowf.abstracts.enums import JobStatusCode, SubmissionCode, \
+    CancelCode
 from maestrowf.abstracts.interfaces import ScriptAdapter
 
 LOGGER = logging.getLogger(__name__)
@@ -105,6 +106,15 @@ class LocalScriptAdapter(ScriptAdapter):
         identifiers to their status.
         """
         return JobStatusCode.NOJOBS, {}
+
+    def cancel_jobs(self, joblist):
+        """
+        For the given job list, cancel each job.
+
+        :param joblist: A list of job identifiers to be cancelled.
+        :returns: The return code to indicate if jobs were cancelled.
+        """
+        return CancelCode.OK
 
     def submit(self, step, path, cwd, job_map=None, env=None):
         """

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -73,6 +73,8 @@ def setup_argparser():
                         help="Check the status of the ExecutionGraph "
                         "located as specified by the 'directory' "
                         "argument.")
+    parser.add_argument("-C", "--cancel", action="store_true",
+                        help="Cancel all running jobs.")
     parser.add_argument("-l", "--logpath", type=str,
                         help="Alternate path to store program logging.")
     parser.add_argument("-d", "--debug_lvl", type=int, default=2,
@@ -163,6 +165,13 @@ def main():
                 pass
 
         return
+
+    if args.cancel:
+        study_path = os.path.split(args.specification)[0]
+        lock_path = os.path.join(study_path, ".cancel.lock")
+        with open(lock_path, 'a'):
+            os.utime(lock_path, None)
+        sys.exit(0)
 
     # Load the Specification
     spec = YAMLSpecification.load_specification(args.specification)


### PR DESCRIPTION
Allow a user to request that a study be cancelled. Maestro will
generate a cancel.lock file to signal the conductor to cancel all
remaining jobs. Add functionality to cancel jobs to the scriptadaptor
interface and implement the functionality in both the local and slurm
script adapters.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>