### PR TITLE
Introduce subparsers for subcommands

### DIFF
--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -55,26 +55,134 @@ LFORMAT = "%(asctime)s - %(name)s:%(funcName)s:%(lineno)s - " \
 ACCEPTED_INPUT = set(["yes", "y"])
 
 
+def status_study(args):
+    """
+    Method for maestro status subcommand.
+    """
+    study_path = args.directory
+    stat_path = os.path.join(study_path, "status.csv")
+    lock_path = os.path.join(study_path, ".status.lock")
+    if os.path.exists(stat_path):
+        lock = FileLock(lock_path)
+        try:
+            with lock.acquire(timeout=10):
+                with open(stat_path, "r") as stat_file:
+                    _ = csvtable_to_dict(stat_file)
+                    print(tabulate.tabulate(_, headers="keys"))
+        except Timeout:
+            pass
+
+    return 0
+
+
+def cancel_study(args):
+    if not os.path.isdir(args.directory):
+        return 1
+
+    lock_path = os.path.join(args.directory, ".cancel.lock")
+
+    with open(lock_path, 'a'):
+        os.utime(lock_path, None)
+
+    return 0
+
+
+def run_study(args):
+    """
+    Method for maestro run subcommand.
+    """
+    # Load the Specification
+    spec = YAMLSpecification.load_specification(args.specification)
+    environment = spec.get_study_environment()
+    parameters = spec.get_parameters()
+    steps = spec.get_study_steps()
+
+    # Addition of the $(SPECROOT) to the environment.
+    spec_root = os.path.split(args.specification)[0]
+    spec_root = Variable("SPECROOT", os.path.abspath(spec_root))
+    environment.add(spec_root)
+
+    # Setup the study.
+    study = Study(spec.name, spec.description, studyenv=environment,
+                  parameters=parameters, steps=steps)
+    study.setup()
+    setup_logging(args, study.output_path, study.name)
+
+    # Stage the study.
+    path, exec_dag = study.stage()
+
+    if not spec.batch:
+        exec_dag.set_adapter({"type": "local"})
+    else:
+        exec_dag.set_adapter(spec.batch)
+
+    # Copy the spec to the output directory
+    shutil.copy(args.specification, path)
+
+    # Generate scripts
+    exec_dag.generate_scripts()
+    exec_dag.pickle(os.path.join(path, "{}.pkl".format(study.name)))
+
+    # If we are automatically launching, just set the input as yes.
+    if args.autoyes:
+        uinput = "y"
+    else:
+        uinput = six.moves.input("Would you like to launch the study?[yn] ")
+
+    if uinput.lower() in ACCEPTED_INPUT:
+        # Launch manager with nohup
+        cmd = ["nohup", "conductor",
+               "-t", str(args.sleeptime),
+               "-d", str(args.debug_lvl),
+               path,
+               "&>", "{}.txt".format(os.path.join(
+                study.output_path, exec_dag.name))]
+        LOGGER.debug(" ".join(cmd))
+        Popen(" ".join(cmd), shell=True, stdout=PIPE, stderr=PIPE)
+
+    return 0
+
+
 def setup_argparser():
     """
     Method for setting up the program's argument parser.
     """
-
-    parser = ArgumentParser(prog="MaestroWF",
+    parser = ArgumentParser(prog="maestro",
                             description="The Maestro Workflow Conductor for "
                             "specifiying, launching, and managing general "
                             "workflows.",
                             formatter_class=RawTextHelpFormatter)
+    subparsers = parser.add_subparsers(dest='subparser')
 
-    parser.add_argument("specification", type=str, help="The path to a Study"
-                        " YAML specification that will be loaded and "
-                        "executed.")
-    parser.add_argument("-s", "--status", action="store_true",
-                        help="Check the status of the ExecutionGraph "
-                        "located as specified by the 'directory' "
-                        "argument.")
-    parser.add_argument("-C", "--cancel", action="store_true",
-                        help="Cancel all running jobs.")
+    # subparser for a cancel subcommand
+    cancel = subparsers.add_parser('cancel',
+                                   help="Cancel all running jobs.")
+    cancel.add_argument("directory", type=str,
+                        help="Directory containing a launched study.")
+    cancel.set_defaults(func=cancel_study)
+
+    # subparser for a run subcommand
+    run = subparsers.add_parser('run',
+                                help="Launch a study based on a specification")
+    run.add_argument("-t", "--sleeptime", type=int, default=60,
+                     help="Amount of time (in seconds) for the manager to "
+                     "wait between job status checks.")
+    run.add_argument("-y", "--autoyes", action="store_true", default=False,
+                     help="Automatically answer yes to input prompts.")
+    run.add_argument("specification", type=str, help="The path to a Study "
+                     "YAML specification that will be loaded and "
+                     "executed.")
+    run.set_defaults(func=run_study)
+
+    # subparser for a status subcommand
+    status = subparsers.add_parser('status',
+                                   help="Check the status of a "
+                                   "running study.")
+    status.add_argument("directory", type=str,
+                        help="Directory containing a launched study.")
+    status.set_defaults(func=status_study)
+
+    # global options
     parser.add_argument("-l", "--logpath", type=str,
                         help="Alternate path to store program logging.")
     parser.add_argument("-d", "--debug_lvl", type=int, default=2,
@@ -86,11 +194,6 @@ def setup_argparser():
                              "1 - Debug")
     parser.add_argument("-c", "--logstdout", action="store_true",
                         help="Log to stdout in addition to a file.")
-    parser.add_argument("-t", "--sleeptime", type=int, default=60,
-                        help="Amount of time (in seconds) for the manager to "
-                        "wait between job status checks.")
-    parser.add_argument("-y", "--autoyes", action="store_true", default=False,
-                        help="Automatically answer yes to input prompts.")
 
     return parser
 
@@ -150,79 +253,8 @@ def main():
     parser = setup_argparser()
     args = parser.parse_args()
 
-    if args.status:
-        study_path = os.path.split(args.specification)[0]
-        stat_path = os.path.join(study_path, "status.csv")
-        lock_path = os.path.join(study_path, ".status.lock")
-        if os.path.exists(stat_path):
-            lock = FileLock(lock_path)
-            try:
-                with lock.acquire(timeout=10):
-                    with open(stat_path, "r") as stat_file:
-                        _ = csvtable_to_dict(stat_file)
-                        print(tabulate.tabulate(_, headers="keys"))
-            except Timeout:
-                pass
-
-        return
-
-    if args.cancel:
-        study_path = os.path.split(args.specification)[0]
-        lock_path = os.path.join(study_path, ".cancel.lock")
-        with open(lock_path, 'a'):
-            os.utime(lock_path, None)
-        sys.exit(0)
-
-    # Load the Specification
-    spec = YAMLSpecification.load_specification(args.specification)
-    environment = spec.get_study_environment()
-    parameters = spec.get_parameters()
-    steps = spec.get_study_steps()
-
-    # Addition of the $(SPECROOT) to the environment.
-    spec_root = os.path.split(args.specification)[0]
-    spec_root = Variable("SPECROOT", os.path.abspath(spec_root))
-    environment.add(spec_root)
-
-    # Setup the study.
-    study = Study(spec.name, spec.description, studyenv=environment,
-                  parameters=parameters, steps=steps)
-    study.setup()
-    setup_logging(args, study.output_path, study.name)
-
-    # Stage the study.
-    path, exec_dag = study.stage()
-
-    if not spec.batch:
-        exec_dag.set_adapter({"type": "local"})
-    else:
-        exec_dag.set_adapter(spec.batch)
-
-    # Copy the spec to the output directory
-    shutil.copy(args.specification, path)
-
-    # Generate scripts
-    exec_dag.generate_scripts()
-    exec_dag.pickle(os.path.join(path, "{}.pkl".format(study.name)))
-
-    # If we are automatically launching, just set the input as yes.
-    if args.autoyes:
-        uinput = "y"
-    else:
-        uinput = six.moves.input("Would you like to launch the study?[yn] ")
-
-    if uinput.lower() in ACCEPTED_INPUT:
-        # Launch manager with nohup
-        cmd = ["nohup", "conductor",
-               "-t", str(args.sleeptime),
-               "-d", str(args.debug_lvl),
-               path,
-               "&>", "{}.txt".format(os.path.join(
-                study.output_path, exec_dag.name))]
-        LOGGER.debug(" ".join(cmd))
-        Popen(" ".join(cmd), shell=True, stdout=PIPE, stderr=PIPE)
-
-    sys.exit(0)
+    rc = args.func(args)
+    sys.exit(rc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use argparse's subparser functionality to implement a "run" and
"status" subcommand. This lays the infrastructure necessary for
future subcommands and is overall cleaner.

TODO - I still need to sort out the use of `setup_logging`.