### PR TITLE
Adds support for enhanced launcher token notations.

### DIFF
--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -110,7 +110,7 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
 
         return "\n".join(modified_header)
 
-    def get_parallelize_command(self, procs, nodes=1):
+    def get_parallelize_command(self, procs, nodes=None):
         """
         Generate the SLURM parallelization segement of the command line.
 
@@ -123,13 +123,16 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
         args = [
             # SLURM srun command
             self._cmd_flags["cmd"],
-            # Nodes segment
-            self._cmd_flags["nodes"],
-            str(nodes),
             # Processors segment
             self._cmd_flags["ntasks"],
             str(procs)
         ]
+
+        if nodes:
+            args += [
+                self._cmd_flags["nodes"],
+                str(nodes),
+            ]
 
         return " ".join(args)
 

--- a/samples/documentation/launcher_tokens.yaml
+++ b/samples/documentation/launcher_tokens.yaml
@@ -1,0 +1,78 @@
+description:
+    name: launcher_examples
+    description: Examples of how to launch cluster workflows.
+env:
+    variables:
+        OUTPUT_PATH: ./sample_output/documentation
+
+batch:
+    type: slurm
+    queue: queue_name
+    bank: bank_name
+    host: hostname
+    nodes: 1
+
+study:
+    - name: legacy-token
+      description:
+          The legacy format for specifying node and task breakdown. Both nodes
+          and procs are required for this format.
+      run:
+          cmd: |
+            $(LAUNCHER)[1,1] echo "Test print #1"
+            $(LAUNCHER)[1,1] echo "Test print #2"
+          nodes: 2
+          procs: 2
+          depends: []
+
+    - name: legacy-token-prepend
+      description:
+          The legacy format for simply appending all of the step's resources to
+          a single command. Procs is the only resource required for this format.
+      run:
+          cmd: |
+            $(LAUNCHER) echo "Test print #1"
+          nodes: 1
+          procs: 1
+          depends: []
+
+    - name: legacy-token-prepend-procs
+      description:
+          The legacy format for simply appending all of the step's resources to
+          a single command. Procs is the only resource required for this format.
+      run:
+          cmd: |
+            $(LAUNCHER) echo "Test print #1"
+          procs: 1
+          depends: []
+
+    - name: command-prepend
+      description:
+          This format automatically prepends the scheduler appropriate MPI
+          command. Procs is the only required resource.
+      run:
+          cmd: |
+            echo "Test print #1"
+          nodes: 1
+          procs: 1
+          depends: []
+
+    - name: full-new-format
+      description:
+          Newest format for specifying resource allocation. Only requires procs.
+      run:
+          cmd: |
+            $(LAUNCHER)[1p, 1n] echo "Test print #1"
+            $(LAUNCHER)[1n, 1p] echo "Test print #2"
+          nodes: 2
+          procs: 2
+          depends: []
+
+    - name: procs-new-format
+      description:
+          Newest format for specifying resource allocation. Only requires procs.
+      run:
+          cmd: |
+            $(LAUNCHER)[1p] echo "Test print #1"
+          procs: 1
+          depends: []


### PR DESCRIPTION
This PR continues to support the legacy notation of $(LAUNCHER)[n,p],
where n is the number of nodes a command requires and p is the number
of processors. This notation is expanded to loosen the requirement for
nodes (except in the legacy notation above) and changes the notation to
allow for more flexibility (nodes and processors can be notated out of
the above order). The new notations becomes $(LAUNCHER)[#n, #p] where
'#n' is not required ($(LAUNCHER)[#p] is also valid). See the study in
samples/documentation/launcher_tokens.yaml. Closes #30.

Initial logic and new regex.

Logic for parsing out launcher tokens.

Addition of a case for when launcher token appears on its own.

Update to the SLURM adapter to supposed unset node counts.

Added launcher token documentation study file.

Bug fixes for regex matching and processing.

Signed-off-by: Francesco Di Natale <dinatale3@llnl.gov>