### PR TITLE
Fixes a bug where restart logic uses the old _submit_record method.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -605,7 +605,7 @@ class ExecutionGraph(DAG):
                             "Step '%s' timed out. Restarting (%s of %s).",
                             name, record.restarts, record.restart_limit
                         )
-                        self._submit_record(name, record, restart=True)
+                        self._execute_record(record, restart=True)
                     else:
                         logger.info("'%s' has been restarted %s of %s times. "
                                     "Marking step and all descendents as "


### PR DESCRIPTION
The `ExecutionGraph` previously used a method called `_submit_record`. During the time where local execution was introduced, the code was cleaned up with a method called `_execute_record`. This PR simply replaces the old method with the new one.