### PR TITLE
Adds the ability to specify reservations and other scheduling parameters.

### DIFF
--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -94,7 +94,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
         pass
 
     @abstractmethod
-    def get_parallelize_command(self, nodes, proc, **kwargs):
+    def get_parallelize_command(self, procs, nodes, **kwargs):
         """
         Generate the parallelization segement of the command line.
 

--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -94,7 +94,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
         pass
 
     @abstractmethod
-    def get_parallelize_command(self, **kwargs):
+    def get_parallelize_command(self, nodes, proc, **kwargs):
         """
         Generate the parallelization segement of the command line.
 
@@ -118,6 +118,8 @@ class SchedulerScriptAdapter(ScriptAdapter):
         err_msg = "{} attempting to allocate {} {} for a parallel call with" \
                   " a maximum allocation of {}"
 
+        nodes = kwargs.pop("nodes")
+        procs = kwargs.pop("procs")
         LOGGER.debug("nodes=%s; procs=%s", nodes, procs)
         LOGGER.debug("step_cmd=%s", step_cmd)
         # See if the command contains a launcher token in it.
@@ -203,7 +205,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
                     LOGGER.error(msg)
                     raise ValueError(msg)
 
-                pcmd = self.get_parallelize_command(_procs, _nodes)
+                pcmd = self.get_parallelize_command(_procs, _nodes, **kwargs)
                 cmd = cmd.replace(match.group(), pcmd)
 
             # Verify that the total nodes/procs used is within maximum.
@@ -222,7 +224,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
             return cmd
         else:
             # 3. If not using launcher token,then just prepend.
-            pcmd = self.get_parallelize_command(procs, nodes)
+            pcmd = self.get_parallelize_command(procs, nodes, **kwargs)
             # Catch the case where the launcher token appears on its own
             if self.launcher_var in step_cmd:
                 LOGGER.debug("'%s' found in cmd -- %s",

--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -48,6 +48,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
     constructing parallel commands. The adapter will substitute parallelized
     commands but also defines how to schedule and check job status.
     """
+
     # The var tag to look for to replace for parallelized commands.
     launcher_var = "$(LAUNCHER)"
     # Allocation regex and compilation
@@ -64,9 +65,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
     node_alloc = r"(?P<nodes>[0-9]+)n"
 
     def __init__(self):
-        """
-        Initialize an empty ScriptAdapter object.
-        """
+        """Initialize an empty ScriptAdapter object."""
         # NOTE: The _batch member should be used to store persistent batching
         # parameters. The entries in this dictionary are meant to capture the
         # the base settings for submission to a batch. This member variables
@@ -95,7 +94,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
         pass
 
     @abstractmethod
-    def get_parallelize_command(self, procs, nodes=None):
+    def get_parallelize_command(self, **kwargs):
         """
         Generate the parallelization segement of the command line.
 
@@ -107,7 +106,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
         """
         pass
 
-    def _substitute_parallel_command(self, step_cmd, nodes, procs):
+    def _substitute_parallel_command(self, step_cmd, **kwargs):
         """
         Substitute parallelized segements into a specified command.
 
@@ -255,14 +254,11 @@ class SchedulerScriptAdapter(ScriptAdapter):
 
         # If the user is requesting nodes, we need to request the nodes and
         # set up the command with scheduling.
-        step_nodes = step.run.get("nodes")
-        step_procs = step.run.get("procs")
-        if step_nodes or step_procs:
+        if "nodes" in step.run or "procs" in step.run:
             to_be_scheduled = True
             cmd = self._substitute_parallel_command(
                 step.run["cmd"],
-                step_nodes,
-                step_procs
+                **step.run
             )
             LOGGER.debug("Scheduling command: %s", cmd)
 
@@ -271,8 +267,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
             if step.run["restart"]:
                 restart = self._substitute_parallel_command(
                     step.run["restart"],
-                    step_nodes,
-                    step_procs
+                    **step.run
                 )
                 LOGGER.debug("Restart command: %s", cmd)
             LOGGER.info("Scheduling workflow step '%s'.", step.name)

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -72,7 +72,8 @@ class StudyStep(SimObject):
                         "restart": "",
                         "nodes": "",
                         "procs": "",
-                        "walltime": ""
+                        "walltime": "",
+                        "reservation": ""
                     }
 
     def apply_parameters(self, combo):

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -72,8 +72,7 @@ class StudyStep(SimObject):
                         "restart": "",
                         "nodes": "",
                         "procs": "",
-                        "walltime": "",
-                        "reservation": ""
+                        "walltime": ""
                     }
 
     def apply_parameters(self, combo):

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -42,9 +42,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class SlurmScriptAdapter(SchedulerScriptAdapter):
-    """
-    A ScriptAdapter class for interfacing with the SLURM cluster scheduler.
-    """
+    """A ScriptAdapter class for interfacing with the SLURM scheduler."""
+
     def __init__(self, **kwargs):
         """
         Initialize an instance of the SlurmScriptAdapter.

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -157,17 +157,16 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
         :returns: The return status of the submission command and job
         identiifer.
         """
+        # Leading command is 'sbatch'
+        cmd = ["sbatch"]
         # Check and see if we should be submitting into a reservation.
-        if self._batch["reservation"]:
-            cmd = " ".join(
-                [
-                    "sbatch",
-                    "--reservation", self._batch["reservation"],
-                    "-D", cwd, path
-                ]
-            )
-        else:
-            cmd = " ".join(["sbatch", path, "-D", cwd])
+        rsvp = self._batch.pop("reservation", "")
+        if rsvp:
+            cmd += ["--reservation", rsvp]
+
+        # Append the script path and working directory.
+        cmd += [path, "-D", cwd]
+        cmd = " ".join(cmd)
 
         LOGGER.debug("cwd = %s", cwd)
         LOGGER.debug("Command to execute: %s", cmd)

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -111,7 +111,7 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
 
         return "\n".join(modified_header)
 
-    def get_parallelize_command(self, procs, nodes=None):
+    def get_parallelize_command(self, procs, nodes=None, **kwargs):
         """
         Generate the SLURM parallelization segement of the command line.
 
@@ -133,6 +133,13 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
             args += [
                 self._cmd_flags["nodes"],
                 str(nodes),
+            ]
+
+        rsvp = kwargs.pop("reservation", "")
+        if rsvp:
+            args += [
+                self._cmd_flags["reservation"],
+                "\"{}\"".format(str(rsvp))
             ]
 
         return " ".join(args)

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -107,6 +107,10 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
 
         modified_header = [self._exec]
         for key, value in self._header.items():
+            # If we're looking at the bank and the reservation header exists,
+            # skip the bank to prefer the reservation.
+            if key == "bank" and "reservation" in self._batch:
+                continue
             modified_header.append(value.format(**batch_header))
 
         return "\n".join(modified_header)


### PR DESCRIPTION
This PR was originally meant to just add reservations, but the abstract interfaces needed to be updated to support it. There were updates and some clean up to the abstract `SchedulerScriptAdapter` and `ScriptAdapter`. The `SchedulerScriptAdapter` now passes a `**kwargs` parameter to support a more flexible range of parameters.

NOTE: This PR is a precursor to a wider change to how resources will be specified in the specification per step.