### PR TITLE
Fix to correct passing an empty jobid list to SLURM cancel.

### DIFF
--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -240,6 +240,10 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
         :param joblist: A list of job identifiers to be cancelled.
         :returns: The return code to indicate if jobs were cancelled.
         """
+        # If we don't have any jobs to check, just return status OK.
+        if not joblist:
+            return CancelCode.OK
+
         cmd = "scancel --quiet {}".format(" ".join(joblist))
         p = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
         output, err = p.communicate()


### PR DESCRIPTION
Corrects a minor bug that causes the SLURM cancel to return an abnormal CancelCode exit by running the cancel command with an empty job ID list.