### PR TITLE
Correction of how dependency ordering happens during study construction.

### DIFF
--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -268,9 +268,9 @@ class SchedulerScriptAdapter(ScriptAdapter):
 
         # If the user is requesting nodes, we need to request the nodes and
         # set up the command with scheduling.
-        _procs = step.run.get("procs")
-        _nodes = step.run.get("nodes")
-        if _procs or _nodes:
+        _nodes = step.run.get("nodes", 0)
+        _procs = step.run.get("procs", 0)
+        if _nodes or _procs:
             to_be_scheduled = True
             cmd = self._substitute_parallel_command(
                 step.run["cmd"],

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -1,6 +1,5 @@
 """Module for the execution of DAG workflows."""
 from collections import deque
-import copy
 from datetime import datetime
 from filelock import FileLock, Timeout
 import getpass
@@ -360,7 +359,7 @@ class ExecutionGraph(DAG):
         :param restart_limit: Upper limit on the number of restart attempts.
         """
         data = {
-                    "step": copy.deepcopy(step),
+                    "step": step,
                     "state": State.INITIALIZED,
                     "workspace": workspace,
                     "restart_limit": restart_limit

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -33,7 +33,6 @@ import copy
 import logging
 import os
 import re
-import string
 import time
 
 from maestrowf.abstracts import SimObject
@@ -703,10 +702,3 @@ class Study(DAG):
             return self._setup_parameterized()
         else:
             return self._setup_linear()
-
-    def _make_safe_path(*args):
-        valid = "-_.() {}{}".format(string.ascii_letters, string.digits)
-        for arg in args:
-            arg = "".join(c for c in arg if c in valid)
-            arg = arg.replace(" ", "_")
-        return os.path.join(*args)

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -498,7 +498,7 @@ class Study(DAG):
                     logger.debug("Processing regular dependencies.")
                     for parent in depends[step]:
                         logger.info("Adding edge (%s, %s)...", parent, step)
-                        dag.add_edge(parent, step)
+                        dag.add_connection(parent, step)
 
                     # We can still have a case where we have steps that do
                     # funnel into this one even though this particular step
@@ -507,11 +507,11 @@ class Study(DAG):
                     for parent in hub_depends[step]:
                         for item in step_combos[parent]:
                             logger.info("Adding edge (%s, %s)...", item, step)
-                            dag.add_edge(item, step)
+                            dag.add_connection(item, step)
                 else:
                     # Otherwise, just add source since we're not dependent.
                     logger.debug("Adding edge (%s, %s)...", SOURCE, step)
-                    dag.add_edge(SOURCE, step)
+                    dag.add_connection(SOURCE, step)
 
             # 2. The step has used parameters.
             else:
@@ -596,7 +596,7 @@ class Study(DAG):
                             logger.info(
                                 "Adding edge (%s, %s)...", p, combo_str
                             )
-                            dag.add_edge(p, combo_str)
+                            dag.add_connection(p, combo_str)
 
                         # We can still have a case where we have steps that do
                         # funnel into this one even though this particular step
@@ -607,13 +607,13 @@ class Study(DAG):
                                 logger.info(
                                     "Adding edge (%s, %s)...", item, combo_str
                                 )
-                                dag.add_edge(item, combo_str)
+                                dag.add_connection(item, combo_str)
                     else:
                         # Otherwise, just add source since we're not dependent.
                         logger.debug(
                             "Adding edge (%s, %s)...", SOURCE, combo_str
                         )
-                        dag.add_edge(SOURCE, combo_str)
+                        dag.add_connection(SOURCE, combo_str)
 
         return self._out_path, dag
 
@@ -660,13 +660,13 @@ class Study(DAG):
             # If the node does not depend on any other steps, make it so that
             # if connects to SOURCE.
             if not node.run["depends"]:
-                dag.add_edge(SOURCE, step)
+                dag.add_connection(SOURCE, step)
             else:
                 # In this case, since our step names are not parameterized,
                 # and due to topological sort, we can guarantee that our
                 # dependencies have been added. Go through and add each edge.
                 for parent in node.run["depends"]:
-                    dag.add_edge(parent, step)
+                    dag.add_connection(parent, step)
 
         return self._out_path, dag
 

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -33,6 +33,7 @@ import copy
 import logging
 import os
 import re
+import string
 import time
 
 from maestrowf.abstracts import SimObject
@@ -702,3 +703,10 @@ class Study(DAG):
             return self._setup_parameterized()
         else:
             return self._setup_linear()
+
+    def _make_safe_path(*args):
+        valid = "-_.() {}{}".format(string.ascii_letters, string.digits)
+        for arg in args:
+            arg = "".join(c for c in arg if c in valid)
+            arg = arg.replace(" ", "_")
+        return os.path.join(*args)

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -469,6 +469,7 @@ class Study(DAG):
                     logger.info("Workspace found -- %s", match)
                     workspace_var = "$({}.workspace)".format(match)
                     ncmd = ncmd.replace(workspace_var, workspaces[match])
+                node.run["cmd"] = ncmd
                 logger.info("New cmd = %s", ncmd)
 
                 dag.add_step(step, node, workspace, rlimit)
@@ -536,11 +537,15 @@ class Study(DAG):
                         # Construct the workspace variable.
                         workspace_var = "$({}.workspace)".format(match)
                         # Construct the parameterized workspace.
-                        ws = "{}_{}".format(
-                            match, combo.get_param_string(used_params[match])
-                        )
+                        if not used_params[match]:
+                            ws = match
+                        else:
+                            ws = "{}_{}".format(
+                                match,
+                                combo.get_param_string(used_params[match])
+                            )
                         logger.info("Workspace found -- %s", ws)
-                        cmd = cmd.replace(workspace_var, ws)
+                        cmd = cmd.replace(workspace_var, workspaces[ws])
                     logger.info("New cmd = %s", cmd)
 
                     step_exp.run["cmd"] = cmd

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -253,7 +253,13 @@ class Study(DAG):
             for dependency in step.run["depends"]:
                 logger.info("{0} is dependent on {1}. Creating edge ("
                             "{1}, {0})...".format(step.name, dependency))
-                self.add_edge(dependency, step.name)
+                if "*" not in dependency:
+                    self.add_edge(dependency, step.name)
+                else:
+                    self.add_edge(
+                        re.sub(ALL_COMBOS, "", dependency),
+                        step.name
+                    )
         else:
             # Otherwise, if no other dependency, just execute the step.
             self.add_edge(SOURCE, step.name)
@@ -397,16 +403,17 @@ class Study(DAG):
                 # produced combinations as dependencies.
                 if "*" in parent:
                     hub_node = True
-                    parent = re.sub(ALL_COMBOS, "")  # If NOTE, continue here.
+                    parent = re.sub(ALL_COMBOS, "", parent)  # If NOTE, continue here.
                 p_params |= used_params[parent]
             # Total parameters used for this step are the union of each parent
             # and the union of the parameters used by this step.
             used_params[step] = p_params | s_params
             parent_params[step] = p_params
 
-            # TODO: Search for workspace matches. We'll have to handle these
+            # Search for workspace matches. We'll have to handle these
             # per case, because how workspaces work will vary based on node
             # type.
+            used_spaces = re.findall(WSREGEX, node.run["cmd"])
 
             # Check for a restart and set the rlimit accordingly.
             if node.run["restart"]:
@@ -416,28 +423,46 @@ class Study(DAG):
 
             # 1. The step and all its preceding parents use no parameters.
             if not used_params[step]:
+                logger.info(
+                    "==================================================\n"
+                    "Adding step '%s' (No parameters used)\n"
+                    "==================================================\n",
+                    self.name
+                )
                 # If we're not using any parameters at all, we do:
                 # Copy the step and set to not modified.
-                logger.debug("No parameters for '%s'. Adding once.", step)
                 step_combos[step] = set([step])
 
                 workspace = self._make_safe_path(global_workspace, step.name)
                 workspaces[step] = workspace
-                dag.add_step(step, node, workspace, rlimit)
-
-                if node.run["depends"]:
-                    # So, because we don't have used parameters, we can just
-                    # loop over the dependencies and add them.
-                    for parent in node.run["depends"]:
-                        dag.add_edge(parent, step)
-                else:
-                    # Otherwise, just add source since we're not dependent.
-                    dag.add_edge(step, SOURCE)
 
                 # NOTE: I don't think it's valid to have a specific workspace
                 # since a step with no parameters operates at the global level.
                 # TODO: Need to handle workspaces here since we don't have
                 # parameters.
+                cmd = node.run["cmd"]
+                logger.info("Searching for workspaces...\ncmd = %s", cmd)
+                for match in used_spaces:
+                    logger.info("Workspace found -- %s", match)
+                    workspace_var = "$({}.workspace)".format(match)
+                    cmd = cmd.replace(workspace_var, workspaces[match])
+                logger.info("New cmd = %s", cmd)
+                node.run["cmd"] = cmd
+
+                dag.add_step(step, node, workspace, rlimit)
+                step_combos[step] = {step}
+
+                if node.run["depends"]:
+                    # So, because we don't have used parameters, we can just
+                    # loop over the dependencies and add them.
+                    for parent in node.run["depends"]:
+                        logger.debug("Adding edge (%s, %s)...", parent, step)
+                        dag.add_edge(parent, step)
+                else:
+                    # Otherwise, just add source since we're not dependent.
+                    logger.debug("Adding edge (%s, %s)...", SOURCE, step)
+                    dag.add_edge(SOURCE, step)
+
             # 2. The step has used parameters.
             else:
                 logger.info(
@@ -464,21 +489,68 @@ class Study(DAG):
                         else:
                             depends.append(parent)
 
-                        if depends:
-                            logger.info("Node type: Parameterized Hub")
-                            # In this case, we now have a hub node that relies
-                            # on all combinations of a particular step and each
-                            #
-                        else:
-                            logger.info("Node type: Unparameterized Hub")
+                    if depends:
+                        logger.info("Node type: Parameterized Hub")
+                        # In this case, we now have a hub node that relies
+                        # on all combinations of a particular step and each
+                        # specific combination of its parents (minus the _*
+                        # included nodes).
+                        # Initialize the set for our step.
+                        step_combos[step] = set()
+                        cmd = node.run["cmd"]
+                        for combo in self.parameters:
+                            # Compute the combination of the step.
+                            combo_str = \
+                                combo.get_param_string(used_params[step])
+                            # Get the workspace directory.
+                            workspaces[combo_str] = self._make_safe_path(
+                                global_workspace, step, combo_str
+                            )
+                            combo_str = "{}_{}".format(step, combo_str)
+                            # If we've already found this combination, skip.
+                            if combo_str in step_combos[step]:
+                                continue
+                            # Otherwise, we just add the step.
+                            step_combos[step].add(combo_str)
+
+                            # Now we need to check for workspaces and sub
+                            # their parameterized strings.
+                            n_cmd = cmd
+                            for match in used_spaces:
+                                logger.info("Workspace found -- %s", match)
+                                tmp = \
+                                    combo.get_param_string(used_params[match])
+                                tmp = "{}_{}".format(
+                                    match, tmp)
+                                ws_var = "$({}.workspace)".format(match, tmp)
+                                n_cmd = cmd.replace(ws_var, workspaces[tmp])
+                            # Add the appropriate combinations for parents.
+                            node.run["cmd"] = n_cmd
+                            dag.add(step, node, workspaces[combo_str], rlimit)
+
+                            # Add all parameterized steps.
+                            for item in depends:
+                                parent = "{}_{}".format(
+                                    item,
+                                    combo.get_param_string(used_params[item])
+                                )
+                                logger.debug("Adding edge (%s, %s)...",
+                                             parent, combo_str)
+                                dag.add_edge(parent, combo_str)
+
+                            # Add all "hub dependencies".
+                            for item in hub_depends:
+                                logger.debug("Adding edge (%s, %s)...",
+                                             item, combo_str)
+                                dag.add_edge(item, combo_str)
+
+                    else:
+                        logger.info("Node type: Unparameterized Hub")
 
                 else:
                     # We do not have a hub node, treat it like a normal one.
-                    if not used_params[step]:
-                        workspace = \
-                            self._make_safe_path(global_workspace, step)
-                        dag.add_step(step, self.values[step], workspace, )
-
+                    # We are also guaranteed to only have a parameterized node
+                    # at this point. So we will have used parameters.
                     for combo in self.parameters:
                         # For each Combination in the parameters...
                         combo_str = combo.get_param_string(used_params[step])

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -510,7 +510,7 @@ class Study(DAG):
                     # is not parameterized.
                     logger.debug("Processing hub dependencies.")
                     for parent in hub_depends[step]:
-                        for item in step_combos["parent"]:
+                        for item in step_combos[parent]:
                             logger.info("Adding edge (%s, %s)...", item, step)
                             hub_depends.append(item)
                 else:
@@ -531,7 +531,10 @@ class Study(DAG):
                 )
                 # Now we iterate over the combinations and expand the step.
                 for combo in self.parameters:
-                    logger.info("\n****** Combo [%s] *****", str(combo))
+                    logger.info("\n**********************************\n"
+                                "Combo [%s]\n"
+                                "**********************************",
+                                str(combo))
                     # Compute this step's combination name and workspace.
                     combo_str = combo.get_param_string(used_params[step])
                     workspace = \
@@ -561,7 +564,7 @@ class Study(DAG):
                         )
                         logger.info("Workspace found -- %s", ws)
                         cmd = cmd.replace(workspace_var, ws)
-                    logger.info("New cmd = %s", ncmd)
+                    logger.info("New cmd = %s", cmd)
 
                     step_exp.run["cmd"] = cmd
                     # Add to the step to the DAG.
@@ -570,14 +573,14 @@ class Study(DAG):
                     if depends[step] or hub_depends[step]:
                         # So, because we don't have used parameters, we can
                         # just loop over the dependencies and add them.
-                        logger.debug("Processing regular dependencies.")
+                        logger.info("Processing regular dependencies.")
                         for p in depends[step]:
                             if used_params[p]:
                                 p = "{}_{}".format(
                                     p, combo.get_param_string(used_params[p])
                                 )
                             logger.info(
-                                "Adding edge (%s, %s)...", p, step
+                                "Adding edge (%s, %s)...", p, combo_str
                             )
                             dag.add_edge(p, combo_str)
 
@@ -586,7 +589,7 @@ class Study(DAG):
                         # is not parameterized.
                         logger.debug("Processing hub dependencies.")
                         for parent in hub_depends[step]:
-                            for item in step_combos["parent"]:
+                            for item in step_combos[parent]:
                                 logger.info(
                                     "Adding edge (%s, %s)...", item, combo_str
                                 )

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -656,7 +656,8 @@ class Study(DAG):
                 rlimit = 0
 
             # Add the step
-            dag.add_step(step, node, self._out_path, rlimit)
+            ws = make_safe_path(self._out_path, step)
+            dag.add_step(step, node, ws, rlimit)
             # If the node does not depend on any other steps, make it so that
             # if connects to SOURCE.
             if not node.run["depends"]:

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -559,7 +559,6 @@ class Study(DAG):
                             # the workspace is the folder that contains all of
                             # the outputs of all combinations for the step.
                             ws = make_safe_path(self._out_path, match)
-                            print self._out_dir
                             logger.info("Found funnel workspace -- %s", ws)
                         elif not used_params[match]:
                             # If it's not a funneled dependency and the match

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -33,14 +33,13 @@ import copy
 import logging
 import os
 import re
-import string
 import time
 
 from maestrowf.abstracts import SimObject
 from maestrowf.datastructures.core import ExecutionGraph
 from maestrowf.datastructures.dag import DAG
 from maestrowf.datastructures.environment import Variable
-from maestrowf.utils import apply_function, create_parentdir
+from maestrowf.utils import apply_function, create_parentdir, make_safe_path
 
 logger = logging.getLogger(__name__)
 SOURCE = "_source"
@@ -368,9 +367,9 @@ class Study(DAG):
         # Items to store that should be reset.
         global_workspace = self.output.value  # Highest ouput dir
         logger.info(
-            "=================================================="
-            "Constructing parameter study '%s'"
-            "==================================================",
+            "\n==================================================\n"
+            "Constructing parameter study '%s'\n"
+            "==================================================\n",
             self.name
         )
 
@@ -404,6 +403,12 @@ class Study(DAG):
         # used parameters of the step, and then adding all parameterized
         # combinations of funneled steps.
         for step in t_sorted:
+            logger.info(
+                "\n==================================================\n"
+                "Adding step '%s'\n"
+                "==================================================\n",
+                step
+            )
             # If we encounter SOURCE, just add it and continue.
             if step == SOURCE:
                 logger.info("Encountered '%s'. Adding and continuing.", SOURCE)
@@ -415,11 +420,12 @@ class Study(DAG):
             node = self.values[step]
             hub_depends[step] = set()
             depends[step] = set()
+            step_combos[step] = set()
 
             s_params = self.parameters.get_used_parameters(node)
             p_params = set()    # Used parameters excluding the current step.
             # Iterate through dependencies to update the p_params
-            logger.debug("*** Processing dependencies ***")
+            logger.debug("\n*** Processing dependencies ***")
             for parent in node.run["depends"]:
                 # If we have a dependency that is parameter independent, add
                 # it to the hub dependency set.
@@ -429,7 +435,7 @@ class Study(DAG):
                 else:
                     logger.debug("Found dependency -- %s", parent)
                     # Otherwise, just note the parameters used by the step.
-                    depends[step] |= parent
+                    depends[step].add(parent)
                     p_params |= used_params[parent]
 
             # Search for workspace matches. These affect the expansion of a
@@ -461,16 +467,16 @@ class Study(DAG):
             # 1. The step and all its preceding parents use no parameters.
             if not used_params[step]:
                 logger.info(
-                    "==================================================\n"
+                    "\n-------------------------------------------------\n"
                     "Adding step '%s' (No parameters used)\n"
-                    "==================================================\n",
-                    self.name
+                    "-------------------------------------------------\n",
+                    step
                 )
                 # If we're not using any parameters at all, we do:
                 # Copy the step and set to not modified.
-                step_combos[step] = {step}
+                step_combos[step].add(step)
 
-                workspace = self._make_safe_path(global_workspace, step)
+                workspace = make_safe_path(global_workspace, step)
                 workspaces[step] = workspace
                 logger.debug("Workspace: %s", workspace)
 
@@ -515,26 +521,27 @@ class Study(DAG):
             # 2. The step has used parameters.
             else:
                 logger.info(
-                    "==================================================\n"
+                    "\n==================================================\n"
                     "Expanding step '%s'\n"
                     "==================================================\n"
                     "-------- Used Parameters --------\n"
                     "%s\n"
                     "---------------------------------",
-                    self.name, str(used_params[step])
+                    step, used_params[step]
                 )
                 # Now we iterate over the combinations and expand the step.
                 for combo in self.parameters:
+                    logger.info("\n****** Combo [%s] *****", str(combo))
                     # Compute this step's combination name and workspace.
                     combo_str = combo.get_param_string(used_params[step])
                     workspace = \
-                        self._make_safe_path(global_workspace, step, combo_str)
+                        make_safe_path(global_workspace, step, combo_str)
                     workspaces[step] = workspace
                     logger.debug("Workspace: %s", workspace)
                     combo_str = "{}_{}".format(step, combo_str)
 
                     # Check if the step combination has been processed.
-                    if combo_str in step_combos[step]:
+                    if combo_str in step_combos:
                         continue
                     # Add this step to the combinations seen.
                     step_combos[step].add(combo_str)
@@ -692,10 +699,3 @@ class Study(DAG):
             return self._setup_parameterized()
         else:
             return self._setup_linear()
-
-    def _make_safe_path(*args):
-        valid = "-_.() {}{}".format(string.ascii_letters, string.digits)
-        for arg in args:
-            arg = "".join(c for c in arg if c in valid)
-            arg = arg.replace(" ", "_")
-        return os.path.join(*args)

--- a/maestrowf/datastructures/dag.py
+++ b/maestrowf/datastructures/dag.py
@@ -171,3 +171,40 @@ class DAG(Graph):
                 path.append(node)
 
         return path, parent
+
+    def _topological_sort(self, v, visited, stack):
+        """
+        Recur through the nodes to perform a toplogical sort.
+
+        :param v: The vertex previously visited.
+        :param visited: A dict of visited statuses.
+        :param stack: The current stack of vertices that have been sorted.
+        :returns: A list of the DAG's nodes in topologically sorted order.
+        """
+
+        # Mark the node as visited.
+        visited[v] = True
+
+        # Recur through the children, visiting children who have not yet been
+        # visited.
+        for e in self.adjacency_table[v]:
+            if not visited[e]:
+                self._topological_sort(e, visited, stack)
+
+        # Prepend v to the front of the list.
+        stack.appendleft(v)
+
+    def topological_sort(self):
+        """
+        Perform a topological ordering of the vertices in the DAG.
+
+        :returns: A list of the vertices sorted in topological order.
+        """
+        v_stack = deque()
+        v_visited = {key: False for key in self.values.keys()}
+
+        for v in self.values:
+            if not v_visited[v]:
+                self._topological_sort(v, v_visited, v_stack)
+
+        return list(v_stack)

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -89,6 +89,7 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
             "reservation": "--reservation",
             "cores per task": "-c",
         }
+        self._unsupported = set(["cmd", "depends", "ntasks", "nodes"])
 
     def get_header(self, step):
         """
@@ -141,9 +142,11 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
                 str(nodes),
             ]
 
-        for key, value in kwargs.items():
+        supported = set(kwargs.keys()) - self._unsupported
+        for key in supported:
+            value = kwargs.get(key)
             if key not in self._cmd_flags:
-                LOGGER.warning("'%s' is not supported -- ommitted.")
+                LOGGER.warning("'%s' is not supported -- ommitted.", key)
                 continue
             if value:
                 args += [

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -32,6 +32,7 @@
 from collections import OrderedDict
 import logging
 import os
+import string
 import time
 
 LOGGER = logging.getLogger(__name__)
@@ -144,3 +145,11 @@ def csvtable_to_dict(fstream):
 
     # Return the completed table
     return table
+
+
+def make_safe_path(*args):
+    valid = "-_.() {}{}".format(string.ascii_letters, string.digits)
+    for arg in args:
+        arg = "".join(c for c in arg if c in valid)
+        arg = arg.replace(" ", "_")
+    return os.path.join(*args)

--- a/samples/lulesh/lulesh_sample1_macosx.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx.yaml
@@ -24,7 +24,7 @@ study:
       description: Build the serial version of LULESH.
       run:
           cmd: |
-            cd $(OUTPUT_PATH)/lulesh
+            cd $(get-lulesh.workspace)/lulesh
             sed -i "" 's/^CXX = $(MPICXX)/CXX = $(SERCXX)/' ./Makefile
             sed -i "" 's/^CXXFLAGS = -g -O3 -fopenmp/#CXXFLAGS = -g -O3 -fopenmp/' ./Makefile
             sed -i "" 's/^#LDFLAGS = -g -O3/LDFLAGS = -g -O3/' ./Makefile
@@ -38,7 +38,7 @@ study:
       description: Run LULESH.
       run:
           cmd: |
-            ../lulesh/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p > $(outfile)
+            $(get-lulesh.workspace)/lulesh/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p > $(outfile)
           depends: [make-lulesh]
 
 global.parameters:

--- a/samples/lulesh/lulesh_sample1_macosx.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx.yaml
@@ -45,6 +45,7 @@ study:
       description: Post process all LULESH results.
       run:
           cmd: |
+            echo "Unparameterized step with Parameter Independent dependencies." >> out.log
             echo $(run-lulesh.workspace) > out.log
             ls $(run-lulesh.workspace) > ls.log
           depends: [run-lulesh_*]
@@ -53,6 +54,7 @@ study:
       description: Post process all LULESH results.
       run:
           cmd: |
+            echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "TRIAL = $(TRIAL)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
             ls $(run-lulesh.workspace) > out.log
@@ -62,6 +64,7 @@ study:
       description: Post process all LULESH results.
       run:
           cmd: |
+            echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "SIZE = $(SIZE)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
             ls $(run-lulesh.workspace) | grep $(SIZE.label) >> out.log

--- a/samples/lulesh/lulesh_sample1_macosx.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx.yaml
@@ -49,7 +49,28 @@ study:
             ls $(run-lulesh.workspace) > ls.log
           depends: [run-lulesh_*]
 
+    - name: post-process-lulesh-trials
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "TRIAL = $(TRIAL)" >> out.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) > out.log
+          depends: [run-lulesh_*]
+
+    - name: post-process-lulesh-size
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "SIZE = $(SIZE)" >> out.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) | grep $(SIZE.label) >> out.log
+          depends: [run-lulesh_*]
+
 global.parameters:
+    TRIAL:
+        values  : [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        label   : TRIAL.%%
     SIZE:
         values  : [10, 10, 10, 20, 20, 20, 30, 30, 30]
         label   : SIZE.%%

--- a/samples/lulesh/lulesh_sample1_macosx.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx.yaml
@@ -41,6 +41,14 @@ study:
             $(get-lulesh.workspace)/lulesh/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p > $(outfile)
           depends: [make-lulesh]
 
+    - name: post-process-lulesh
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) > ls.log
+          depends: [run-lulesh_*]
+
 global.parameters:
     SIZE:
         values  : [10, 10, 10, 20, 20, 20, 30, 30, 30]

--- a/samples/lulesh/lulesh_sample1_unix.yaml
+++ b/samples/lulesh/lulesh_sample1_unix.yaml
@@ -41,6 +41,14 @@ study:
             $(get-lulesh)/lulesh/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p > $(outfile)
           depends: [make-lulesh]
 
+    - name: post-process-lulesh
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) > ls.log
+          depends: [run-lulesh_*]
+
 global.parameters:
     SIZE:
         values  : [10, 10, 10, 20, 20, 20, 30, 30, 30]

--- a/samples/lulesh/lulesh_sample1_unix.yaml
+++ b/samples/lulesh/lulesh_sample1_unix.yaml
@@ -45,6 +45,7 @@ study:
       description: Post process all LULESH results.
       run:
           cmd: |
+            echo "Unparameterized step with Parameter Independent dependencies." >> out.log
             echo $(run-lulesh.workspace) > out.log
             ls $(run-lulesh.workspace) > ls.log
           depends: [run-lulesh_*]
@@ -53,6 +54,7 @@ study:
       description: Post process all LULESH results.
       run:
           cmd: |
+            echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "TRIAL = $(TRIAL)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
             ls $(run-lulesh.workspace) > out.log
@@ -62,6 +64,7 @@ study:
       description: Post process all LULESH results.
       run:
           cmd: |
+            echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "SIZE = $(SIZE)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
             ls $(run-lulesh.workspace) | grep $(SIZE.label) >> out.log

--- a/samples/lulesh/lulesh_sample1_unix.yaml
+++ b/samples/lulesh/lulesh_sample1_unix.yaml
@@ -49,7 +49,28 @@ study:
             ls $(run-lulesh.workspace) > ls.log
           depends: [run-lulesh_*]
 
+    - name: post-process-lulesh-trials
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "TRIAL = $(TRIAL)" >> out.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) > out.log
+          depends: [run-lulesh_*]
+
+    - name: post-process-lulesh-size
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "SIZE = $(SIZE)" >> out.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) | grep $(SIZE.label) >> out.log
+          depends: [run-lulesh_*]
+
 global.parameters:
+    TRIAL:
+        values  : [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        label   : TRIAL.%%
     SIZE:
         values  : [10, 10, 10, 20, 20, 20, 30, 30, 30]
         label   : SIZE.%%

--- a/samples/lulesh/lulesh_sample1_unix.yaml
+++ b/samples/lulesh/lulesh_sample1_unix.yaml
@@ -24,7 +24,7 @@ study:
       description: Build the serial version of LULESH.
       run:
           cmd: |
-            cd $(OUTPUT_PATH)/lulesh
+            cd $(get-lulesh.workspace)/lulesh
             sed -i 's/^CXX = $(MPICXX)/CXX = $(SERCXX)/' ./Makefile
             sed -i 's/^CXXFLAGS = -g -O3 -fopenmp/#CXXFLAGS = -g -O3 -fopenmp/' ./Makefile
             sed -i 's/^#LDFLAGS = -g -O3/LDFLAGS = -g -O3/' ./Makefile
@@ -38,7 +38,7 @@ study:
       description: Run LULESH.
       run:
           cmd: |
-            ../lulesh/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p > $(outfile)
+            $(get-lulesh)/lulesh/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p > $(outfile)
           depends: [make-lulesh]
 
 global.parameters:


### PR DESCRIPTION
Previously Maestro used a spanning tree to find all dependent jobs; however, that method suffered from the issue that steps could be expanded before all their dependencies are. This PR makes it so that Maestro topologically sorts all steps before expanding the Study's DAG into an ExecutionGraph.