### PR TITLE
Correct the inability of accessing the study output root directory.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -46,7 +46,8 @@ class _StepRecord(object):
         tmp_dir: A provided temp directory to write scripts to instead of step
         workspace.
         """
-        self.workspace = Variable("OUTPUT_PATH", workspace)
+        self.workspace = Variable("WORKSPACE", workspace)
+        step.run["cmd"] = self.workspace.substitute(step.run["cmd"])
 
         self.jobid = kwargs.get("jobid", [])
         self.script = kwargs.get("script", "")

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -421,7 +421,7 @@ class Study(DAG):
             for ws in used_spaces:
                 if ws not in used_params:
                     msg = "Workspace for '{}' is being used before it would" \
-                          "be generated.".format(ws)
+                          " be generated.".format(ws)
                     logger.error(msg)
                     raise Exception(msg)
 

--- a/maestrowf/datastructures/core/studyenvironment.py
+++ b/maestrowf/datastructures/core/studyenvironment.py
@@ -160,16 +160,23 @@ class StudyEnvironment(SimObject):
         :returns: The environment object labeled by key.
         """
         logger.debug("Looking to remove '%s'...", key)
+
+        if key not in self._names:
+            return None
+
         _ = self.dependencies.pop(key, None)
         if _ is not None:
+            self._names.remove(key)
             return _
 
         _ = self.substitutions.pop(key, None)
         if _ is not None:
+            self._names.remove(key)
             return _
 
         _ = self.labels.pop(key, None)
         if _ is not None:
+            self._names.remove(key)
             return _
 
         logger.debug("'%s' not found -- \n%s", key, self)

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -133,6 +133,7 @@ def run_study(args):
             time.strftime("%Y%m%d-%H%M%S")
         )
         output_path = make_safe_path(out_dir, out_name)
+    environment.add(Variable("OUTPUT_PATH", output_path))
 
     # Now that we know outpath, set up logging.
     setup_logging(args, output_path, spec.name)

--- a/samples/lulesh/lulesh_sample1_macosx.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx.yaml
@@ -16,8 +16,8 @@ study:
       run:
           cmd: |
             curl -L -o lulesh.tar $(LULESH_URL)
-            mkdir $(OUTPUT_PATH)/lulesh
-            tar -xf lulesh.tar -C $(OUTPUT_PATH)/lulesh
+            mkdir $(WORKSPACE)/lulesh
+            tar -xf lulesh.tar -C $(WORKSPACE)/lulesh
           depends: []
 
     - name: make-lulesh

--- a/samples/lulesh/lulesh_sample1_unix.yaml
+++ b/samples/lulesh/lulesh_sample1_unix.yaml
@@ -16,8 +16,8 @@ study:
       run:
           cmd: |
             curl -L -o lulesh.tar $(LULESH_URL)
-            mkdir $(OUTPUT_PATH)/lulesh
-            tar -xf lulesh.tar -C $(OUTPUT_PATH)/lulesh
+            mkdir $(WORKSPACE)/lulesh
+            tar -xf lulesh.tar -C $(WORKSPACE)/lulesh
           depends: []
 
     - name: make-lulesh


### PR DESCRIPTION
Previously, `OUTPUT_PATH` would refer to the study output path during setup and then to a step's local workspace during a study. There are cases where users would want to read or point to the root directory of an executing study. Therefore, the following nomenclature has been added (and some restated for documentation):

`$(SPECROOT)` = The path to the directory where the original specification that launched the study is located.
`$(OUTPUT_PATH)` = During setup, where the timestamped directory is created. Thereafter, the location of the study output root of the executing study.
`$(WORKSPACE)` = For each step definiton, the local workspace of the step.