### PR TITLE
Correction to handling "cores per task" resource allocation.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -165,8 +165,8 @@ class _StepRecord(object):
         self.status = State.TIMEDOUT
         # Designating a restart limit of zero as an unlimited restart setting.
         # Otherwise, if we're less than restart limit, attempt another restart.
-        if self._restart_limit == 0 or \
-                self._num_restarts < self._restart_limit:
+        if self.restart_limit == 0 or \
+                self._num_restarts < self.restart_limit:
             self._num_restarts += 1
             return True
         else:

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -216,7 +216,7 @@ class Study(DAG):
 
     def add_step(self, step):
         """
-        Helper method for adding steps to a Study instance.
+        Add a step to a study.
 
         For this helper to be most effective, it recommended to apply steps in
         the order that they will be encountered. The method attempts to be
@@ -263,7 +263,7 @@ class Study(DAG):
     def setup(self, submission_attempts=1, restart_limit=1, throttle=0,
               use_tmp=False):
         """
-        Method for executing initial setup of a Study.
+        Perform initial setup of a study.
 
         The method is used for going through and actually acquiring each
         dependency, substituting variables, sources and labels. Also sets up
@@ -673,7 +673,7 @@ class Study(DAG):
 
     def stage(self):
         """
-        Method that produces the expanded DAG representing the Study.
+        Generate the execution graph for a Study.
 
         Staging creates an ExecutionGraph based on the combinations generated
         by the ParameterGeneration object stored in an instance of a Study.

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -72,7 +72,7 @@ class StudyStep(SimObject):
                         "nodes":            "",
                         "procs":            "",
                         "gpus":             "",
-                        "cores per task":   1,
+                        "cores per task":   "",
                         "walltime":         "",
                         "reservation":      ""
                     }

--- a/maestrowf/datastructures/yamlspecification.py
+++ b/maestrowf/datastructures/yamlspecification.py
@@ -85,7 +85,7 @@ class YAMLSpecification(Specification):
     @classmethod
     def load_specification(cls, path):
         """
-        Method for loading a study specification.
+        Load a study specification.
 
         :param path: Path to a study specification.
         :returns: A specification object containing the information from path.

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -216,11 +216,12 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         #     return SubmissionCode.ERROR, -1
 
         walltime = self._convert_walltime_to_seconds(step.run["walltime"])
+        cores_per_task = step.run.get("cores per task", 1)
         jobspec = {
             "nnodes": step.run["nodes"],
             # NOTE: interface doesn"t allow multiple here yet
             "ntasks":   step.run["nodes"],
-            "ncores":   step.run["cores per task"] * step.run["procs"],
+            "ncores":   cores_per_task * step.run["procs"],
             "gpus":     step.run.get("gpus", 0),
             "environ":  get_environment(),          # TODO: revisit
             "options":  {"stdio-delay-commit": 1},

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -151,7 +151,7 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
             if value:
                 args += [
                     self._cmd_flags[key],
-                    "\"{}\"".format(str(value))
+                    "{}".format(str(value))
                 ]
 
         return " ".join(args)


### PR DESCRIPTION
There was a bug that would substitute "cores per task" set to 1 by default as well as placing the value in quotations. Related to this issue, a bad reference to `_restart_limit` in the `_StepRecord` class was also corrected.