### PR TITLE
Correct a bad import and minor bugs with cancel_jobs

### DIFF
--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -374,7 +374,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
                     )
 
                 if retcode != 0:
-                    status = self.check_jobs([job])
+                    retcode, status = self.check_jobs([job])
                     if status and status.get(job, None) in term_status:
                         retcode = 0
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -51,14 +51,11 @@ def get_environment():
     for key in os.environ:
         if env_filter.match(key):
             continue
-        if key.startswith("OMPI"):
-            if "tmpdir_base" not in key:
-                continue
         env[key] = os.environ[key]
     env.pop("HOSTNAME", None)
     env.pop("ENVIRONMENT", None)
     # Make MVAPICH behave...
-    # env["MPIRUN_RSH_LAUNCH"] = "1"
+    env["MPIRUN_RSH_LAUNCH"] = "1"
     return env
 
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -396,7 +396,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             return State.RUNNING
         elif flux_state == "pending" or flux_state == "runrequest":
             return State.PENDING
-        elif flux_state == "submitted":
+        elif flux_state == "submitted" or flux_state == "allocated":
             return State.PENDING
         elif flux_state == "failed":
             return State.FAILED

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -51,11 +51,14 @@ def get_environment():
     for key in os.environ:
         if env_filter.match(key):
             continue
+        if key.startswith("OMPI"):
+            if "tmpdir_base" not in key:
+                continue
         env[key] = os.environ[key]
     env.pop("HOSTNAME", None)
     env.pop("ENVIRONMENT", None)
     # Make MVAPICH behave...
-    env["MPIRUN_RSH_LAUNCH"] = "1"
+    # env["MPIRUN_RSH_LAUNCH"] = "1"
     return env
 
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -89,6 +89,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         # NOTE: Host doesn"t seem to matter for FLUX. sbatch assumes that the
         # current host is where submission occurs.
         self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
+        self._addl_args = kwargs.pop("args", [])
 
         self._exec = "#!/bin/bash"
         # Header is only for informational purposes.
@@ -163,9 +164,11 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "-u", "PMI_RANK",
             "-u", "PMI_SIZE",
             "mpirun",
-            "-gpu",
-            "-mca", "plm", "rsh",
-            "--map-by", "node"]
+            "-gpu"]
+
+        for item in self._addl_args:
+            args.extend(item)
+
         args.extend(["-hostfile", "$HOSTF"])
         args.extend([
             "-n",

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -167,7 +167,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "-gpu"]
 
         for item in self._addl_args:
-            args.extend(item)
+            args.append(item)
 
         args.extend(["-hostfile", "$HOSTF"])
         args.extend([

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -84,7 +84,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         # NOTE: These libraries are compiled at runtime when an allocation
         # is spun up.
         self.flux = __import__("flux")
-        self.kvs = __import__("flux.kvs")
+        self.kvs = __import__("flux.kvs", globals(), locals(), ["kvs"])
 
         # NOTE: Host doesn"t seem to matter for FLUX. sbatch assumes that the
         # current host is where submission occurs.

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -164,8 +164,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "-u", "PMI_FD",
             "-u", "PMI_RANK",
             "-u", "PMI_SIZE",
-            self._mpi_exe,
-            "-gpu"]
+            self._mpi_exe]
 
         for item in self._addl_args:
             args.append(item)

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -89,6 +89,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         # NOTE: Host doesn"t seem to matter for FLUX. sbatch assumes that the
         # current host is where submission occurs.
         self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
+        self._mpi_exe = kwargs.pop("mpi")
         self._addl_args = kwargs.pop("args", [])
 
         self._exec = "#!/bin/bash"
@@ -163,7 +164,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "-u", "PMI_FD",
             "-u", "PMI_RANK",
             "-u", "PMI_SIZE",
-            "mpirun",
+            self._mpi_exe,
             "-gpu"]
 
         for item in self._addl_args:


### PR DESCRIPTION
This PR fixes the `kvs` import so that the module pointed to by `self.kvs` is now the correct one (previously the adapter threw an unknown attribute error when calling the `kvs.get` method). The other fix included is the `.get('status', None)` call in `check_status`.