### PR TITLE
Flux for Spectrum bugfixes

### DIFF
--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -374,7 +374,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
                     )
 
                 if retcode != 0:
-                    status = self.check_jobs([job])
+                    retcode, status = self.check_jobs([job])
                     if status and status.get(job, None) in term_status:
                         retcode = 0
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -51,14 +51,11 @@ def get_environment():
     for key in os.environ:
         if env_filter.match(key):
             continue
-        if key.startswith("OMPI"):
-            if "tmpdir_base" not in key:
-                continue
         env[key] = os.environ[key]
     env.pop("HOSTNAME", None)
     env.pop("ENVIRONMENT", None)
     # Make MVAPICH behave...
-    # env["MPIRUN_RSH_LAUNCH"] = "1"
+    env["MPIRUN_RSH_LAUNCH"] = "1"
     return env
 
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -396,7 +396,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             return State.RUNNING
         elif flux_state == "pending" or flux_state == "runrequest":
             return State.PENDING
-        elif flux_state == "submitted":
+        elif flux_state == "submitted" or flux_state == "allocated":
             return State.PENDING
         elif flux_state == "failed":
             return State.FAILED

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -51,11 +51,14 @@ def get_environment():
     for key in os.environ:
         if env_filter.match(key):
             continue
+        if key.startswith("OMPI"):
+            if "tmpdir_base" not in key:
+                continue
         env[key] = os.environ[key]
     env.pop("HOSTNAME", None)
     env.pop("ENVIRONMENT", None)
     # Make MVAPICH behave...
-    env["MPIRUN_RSH_LAUNCH"] = "1"
+    # env["MPIRUN_RSH_LAUNCH"] = "1"
     return env
 
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -89,6 +89,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         # NOTE: Host doesn"t seem to matter for FLUX. sbatch assumes that the
         # current host is where submission occurs.
         self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
+        self._addl_args = kwargs.pop("args", [])
 
         self._exec = "#!/bin/bash"
         # Header is only for informational purposes.
@@ -163,9 +164,11 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "-u", "PMI_RANK",
             "-u", "PMI_SIZE",
             "mpirun",
-            "-gpu",
-            "-mca", "plm", "rsh",
-            "--map-by", "node"]
+            "-gpu"]
+
+        for item in self._addl_args:
+            args.extend(item)
+
         args.extend(["-hostfile", "$HOSTF"])
         args.extend([
             "-n",

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -167,7 +167,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "-gpu"]
 
         for item in self._addl_args:
-            args.extend(item)
+            args.append(item)
 
         args.extend(["-hostfile", "$HOSTF"])
         args.extend([

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -84,7 +84,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         # NOTE: These libraries are compiled at runtime when an allocation
         # is spun up.
         self.flux = __import__("flux")
-        self.kvs = __import__("flux.kvs")
+        self.kvs = __import__("flux.kvs", globals(), locals(), ["kvs"])
 
         # NOTE: Host doesn"t seem to matter for FLUX. sbatch assumes that the
         # current host is where submission occurs.

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -262,7 +262,8 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             LOGGER.warning("Job creation failed")
             return SubmissionCode.ERROR, -1
 
-        LOGGER.info("Submission returned status OK.")
+        LOGGER.info("Submission returned status OK. -- "
+                    "Assigned identifier (%s)", resp["jobid"])
         return SubmissionCode.OK, resp["jobid"]
 
     def check_jobs(self, joblist):

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -339,7 +339,13 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
                     "Error seen on path {} Unexpected behavior encountered."
                     .format(path)
                 )
+                # NOTE: I don't know if we should actually be returning here.
+                # It feels like we may not want to.
                 return JobStatusCode.ERROR, status
+            except EnvironmentError:
+                LOGGER.warning("Job ID (%s) not found in kvs. Setting state"
+                               "to UNKNOWN.", jobid)
+                status[jobid] = self._state("unknown")
 
         if not status:
             return JobStatusCode.NOJOBS, status
@@ -404,6 +410,8 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             return State.CANCELLED
         elif flux_state == "complete":
             return State.FINISHED
+        elif flux_state == "unknown":
+            return State.UNKNOWN
         else:
             return State.UNKNOWN
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -164,8 +164,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "-u", "PMI_FD",
             "-u", "PMI_RANK",
             "-u", "PMI_SIZE",
-            self._mpi_exe,
-            "-gpu"]
+            self._mpi_exe]
 
         for item in self._addl_args:
             args.append(item)

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -89,6 +89,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         # NOTE: Host doesn"t seem to matter for FLUX. sbatch assumes that the
         # current host is where submission occurs.
         self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
+        self._mpi_exe = kwargs.pop("mpi")
         self._addl_args = kwargs.pop("args", [])
 
         self._exec = "#!/bin/bash"
@@ -163,7 +164,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "-u", "PMI_FD",
             "-u", "PMI_RANK",
             "-u", "PMI_SIZE",
-            "mpirun",
+            self._mpi_exe,
             "-gpu"]
 
         for item in self._addl_args:


### PR DESCRIPTION
This PR includes a number of bugfixes for the Flux adapter.
- Addition of the missed "allocated" state
- Enhancement to make it so that the MPI binary is passed via batch
- Addition of the jobid to logging on submission