### PR TITLE
Refactor of the Study class to breakdown complex APIs

### DIFF
--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -30,6 +30,7 @@
 """Class related to the construction of study campaigns."""
 import copy
 import logging
+import os
 import re
 
 from maestrowf.abstracts import SimObject
@@ -698,10 +699,17 @@ class Study(DAG):
         :param throttle: Maximum number of in progress jobs allowed.
         :returns: An ExecutionGraph object with the expanded workflow.
         """
-        # If not set up, return None.
-        if not self._issetup:
-            msg = "Study {} is not set up for staging. Run setup before " \
-                  "attempting to stage.".format(self.name)
+        # If the workspace doesn't exist, raise an exception.
+        if not os.path.exists(self._out_path):
+            msg = "Study {} is not set up for staging. Workspace does not " \
+                  "exists (Output Dir = {}).".format(self.name, self._out_path)
+            logger.error(msg)
+            raise Exception(msg)
+
+        # If the environment isn't set up, raise an exception.
+        if not self.environment.is_set_up:
+            msg = "Study {} is not set up for staging. Environment is not " \
+                  "set up. Aborting.".format(self.name)
             logger.error(msg)
             raise Exception(msg)
 

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -260,14 +260,22 @@ class Study(DAG):
         for node in path:
             yield parents[node], node, self.values[node]
 
+    def setup_workspace(self):
+        """Set up the study's main workspace directory."""
+        try:
+            logger.info("Setting up study workspace in '%s'", self._out_path)
+            create_parentdir(self._out_path)
+        except Exception as e:
+            logger.error(e.message)
+            return False
+
     def setup(self, submission_attempts=1, restart_limit=1, throttle=0,
               use_tmp=False):
         """
         Perform initial setup of a study.
 
         The method is used for going through and actually acquiring each
-        dependency, substituting variables, sources and labels. Also sets up
-        the folder structure for the study.
+        dependency, substituting variables, sources and labels.
 
         :param submission_attempts: Number of attempted submissions before
             marking a step as failed.
@@ -305,13 +313,6 @@ class Study(DAG):
         if not self.environment.is_set_up:
             logger.info("Environment is setting up.")
             self.environment.acquire_environment()
-
-        try:
-            logger.info("Environment is setting up.")
-            create_parentdir(self._out_path)
-        except Exception as e:
-            logger.error(e.message)
-            return False
 
         # Apply all environment artifcacts and acquire everything.
         for key, node in self.values.items():

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -317,7 +317,7 @@ class Study(DAG):
             use_tmp
         )
 
-    def _setup_parameterized(self):
+    def _stage_parameterized(self):
         """
         Set up the ExecutionGraph of a parameterized study.
 
@@ -613,7 +613,7 @@ class Study(DAG):
 
         return self._out_path, dag
 
-    def _setup_linear(self):
+    def _stage_linear(self):
         """
         Execute a linear workflow without parameters.
 
@@ -737,6 +737,6 @@ class Study(DAG):
         # 2. A linear, execute as specified workflow
         # NOTE: This scheme could be how we handle derived use cases.
         if self.parameters:
-            return self._setup_parameterized()
+            return self._stage_parameterized()
         else:
-            return self._setup_linear()
+            return self._stage_linear()

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -269,10 +269,10 @@ class Study(DAG):
             logger.error(e.message)
             return False
 
-    def setup(self, submission_attempts=1, restart_limit=1, throttle=0,
-              use_tmp=False):
+    def configure_study(self, submission_attempts=1, restart_limit=1, throttle=0,
+                        use_tmp=False):
         """
-        Perform initial setup of a study.
+        Perform initial configuration of a study.
 
         The method is used for going through and actually acquiring each
         dependency, substituting variables, sources and labels.

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -228,6 +228,11 @@ class Study(DAG):
         """
         # Add the node to the DAG.
         self.add_node(step.name, step)
+        logger.info(
+            "Adding step '%s' to study '%s'...", step.name, self.name)
+        # Apply the environment to the incoming step.
+        step.__dict__ = \
+            apply_function(step.__dict__, self.environment.apply_environment)
 
         # If the step depends on a prior step, create an edge.
         if "depends" in step.run and step.run["depends"]:

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -269,8 +269,8 @@ class Study(DAG):
             logger.error(e.message)
             return False
 
-    def configure_study(self, submission_attempts=1, restart_limit=1, throttle=0,
-                        use_tmp=False):
+    def configure_study(self, submission_attempts=1, restart_limit=1,
+                        throttle=0, use_tmp=False):
         """
         Perform initial configuration of a study.
 

--- a/maestrowf/datastructures/core/studyenvironment.py
+++ b/maestrowf/datastructures/core/studyenvironment.py
@@ -183,9 +183,7 @@ class StudyEnvironment(SimObject):
         return None
 
     def acquire_environment(self):
-        """
-        Acquire any environment items that may be stored remotely.
-        """
+        """Acquire any environment items that may be stored remotely."""
         if self._is_set_up:
             logger.info("Environment already set up. Returning.")
             return

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -168,12 +168,9 @@ def run_study(args):
         LOGGER.error(_msg)
         raise ArgumentError(_msg)
 
-    study.setup(
-        throttle=args.throttle,
-        submission_attempts=args.attempts,
-        restart_limit=args.rlimit,
-        use_tmp=args.usetmp
-    )
+    study.setup_workspace()
+    study.setup(throttle=args.throttle, submission_attempts=args.attempts,
+                restart_limit=args.rlimit, use_tmp=args.usetmp)
 
     # Stage the study.
     path, exec_dag = study.stage()

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -168,9 +168,11 @@ def run_study(args):
         LOGGER.error(_msg)
         raise ArgumentError(_msg)
 
+    # Set up the study workspace and configure it for execution.
     study.setup_workspace()
-    study.setup(throttle=args.throttle, submission_attempts=args.attempts,
-                restart_limit=args.rlimit, use_tmp=args.usetmp)
+    study.configure_study(
+        throttle=args.throttle, submission_attempts=args.attempts,
+        restart_limit=args.rlimit, use_tmp=args.usetmp)
 
     # Stage the study.
     path, exec_dag = study.stage()

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -170,6 +170,7 @@ def run_study(args):
 
     # Set up the study workspace and configure it for execution.
     study.setup_workspace()
+    study.setup_environment()
     study.configure_study(
         throttle=args.throttle, submission_attempts=args.attempts,
         restart_limit=args.rlimit, use_tmp=args.usetmp)


### PR DESCRIPTION
This PR primarily targets the `Study.setup(...)` method which was rather monolithic in because it set up the study workspace, acquired dependencies, and configured the settings for study execution. This method has been broken down into multiple calls that stage different parts of the set up process. The names of methods in the Study class have also been fixed to better reflect what they actually do.