### PR TITLE
Updated exception messages

### DIFF
--- a/maestrowf/conductor.py
+++ b/maestrowf/conductor.py
@@ -199,7 +199,7 @@ def main():
         # Explicitly return a 0 status.
         sys.exit(0)
     except Exception as e:
-        logger.error(e.message, exc_info=True)
+        logger.error(e.args, exc_info=True)
         raise e
 
 

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -337,7 +337,7 @@ class Study(DAG):
             logger.info("Setting up study workspace in '%s'", self._out_path)
             create_parentdir(self._out_path)
         except Exception as e:
-            logger.error(e.message)
+            logger.error(e.args)
             return False
 
     def setup_environment(self):

--- a/maestrowf/datastructures/yamlspecification.py
+++ b/maestrowf/datastructures/yamlspecification.py
@@ -97,7 +97,7 @@ class YAMLSpecification(Specification):
                 spec = yaml.load(data)
 
         except Exception as e:
-            logger.exception(e.message)
+            logger.exception(e.args)
             raise
 
         logger.debug("Loaded specification -- \n%s", spec["description"])
@@ -149,7 +149,7 @@ class YAMLSpecification(Specification):
                     raise ValueError("Both 'name' and 'description' must be "
                                      "provided for a valid study description.")
         except Exception as e:
-            logger.exception(e.message)
+            logger.exception(e.args)
             raise
 
         logger.info("Study description verified -- \n%s", self.description)
@@ -275,7 +275,7 @@ class YAMLSpecification(Specification):
             self._verify_steps()
 
         except Exception as e:
-            logger.exception(e.message)
+            logger.exception(e.args)
             raise
 
     def _verify_steps(self):
@@ -310,7 +310,7 @@ class YAMLSpecification(Specification):
                                      "configuration for step named '{}'."
                                      .format(missing_attrs, step["name"]))
         except Exception as e:
-            logger.exception(e.message)
+            logger.exception(e.args)
             raise
 
         logger.debug("Verified")
@@ -377,7 +377,7 @@ class YAMLSpecification(Specification):
                                          .format(name))
 
         except Exception as e:
-            logger.exception(e.message)
+            logger.exception(e.args)
             raise
 
     @property


### PR DESCRIPTION
This pull request addresses ticket #124: BaseException.message has been deprecated as of Python 2.6.