### PR TITLE
Fix status.csv 'State' column writeout.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -603,7 +603,7 @@ class ExecutionGraph(DAG):
             value = self.values[key]
             _ = [
                     value.name, os.path.split(value.workspace.value)[1],
-                    str(value.status), value.run_time, value.elapsed_time,
+                    str(value.status.name), value.run_time, value.elapsed_time,
                     value.time_start, value.time_submitted, value.time_end,
                     str(value.restarts)
                 ]


### PR DESCRIPTION
Addresses issue #126, improper text writeout in ExecutionGraph's write_status method.