### PR TITLE
Addition of custom parameter generation when running studies.

### DIFF
--- a/maestrowf/datastructures/core/parameters.py
+++ b/maestrowf/datastructures/core/parameters.py
@@ -347,3 +347,17 @@ class ParameterGenerator(SimObject):
         params = set()
         self._get_used_parameters(step.__dict__, params)
         return params
+
+    def get_metadata(self):
+        """
+        Produce metadata for the parameters in a generator instance.
+
+        :returns: A dictionary containing metadata about the instance.
+        """
+        meta = {}
+        for combo in self.get_combinations():
+            meta[str(combo)] = {}
+            meta[str(combo)]["params"] = combo._params
+            meta[str(combo)]["labels"] = combo._labels
+
+        return meta

--- a/maestrowf/datastructures/core/parameters.py
+++ b/maestrowf/datastructures/core/parameters.py
@@ -272,7 +272,7 @@ class ParameterGenerator(SimObject):
 
     def __iter__(self):
         """
-        Iterator for the ParameterGenerator.
+        Return the iterator for the ParameterGenerator.
 
         :returns: Iterator for walking parameter combinations.
         """

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -250,7 +250,14 @@ class Study(DAG):
             "used_parameters": self.used_params,
             "step_combinations": self.step_combos,
         }
+        # Write out the study construction metadata.
         path = os.path.join(self._meta_path, "metadata.yaml")
+        with open(path, "wb") as metafile:
+            metafile.write(yaml.dump(metadata).encode("utf-8"))
+
+        # Write out parameter metadata.
+        metadata = self.parameters.get_metadata()
+        path = os.path.join(self._meta_path, "parameters.yaml")
         with open(path, "wb") as metafile:
             metafile.write(yaml.dump(metadata).encode("utf-8"))
 

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -131,12 +131,6 @@ def run_study(args):
     environment = spec.get_study_environment()
     steps = spec.get_study_steps()
 
-    # Handle loading a custom ParameterGenerator if specified.
-    if args.pgen:
-        parameters = load_parameter_generator(args.pgen)
-    else:
-        parameters = spec.get_parameters()
-
     # Set up the output directory.
     out_dir = environment.remove("OUTPUT_PATH")
     if args.out:
@@ -178,6 +172,14 @@ def run_study(args):
 
     # Now that we know outpath, set up logging.
     setup_logging(args, output_path, spec.name.replace(" ", "_").lower())
+
+    # Handle loading a custom ParameterGenerator if specified.
+    if args.pgen:
+        # Copy the Python file used to generate parameters.
+        shutil.copy(args.pgen, output_path)
+        parameters = load_parameter_generator(args.pgen)
+    else:
+        parameters = spec.get_parameters()
 
     # Addition of the $(SPECROOT) to the environment.
     spec_root = os.path.split(args.specification)[0]

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -129,8 +129,13 @@ def run_study(args):
     # Load the Specification
     spec = YAMLSpecification.load_specification(args.specification)
     environment = spec.get_study_environment()
-    parameters = spec.get_parameters()
     steps = spec.get_study_steps()
+
+    # Handle loading a custom ParameterGenerator if specified.
+    if args.pgen:
+        parameters = load_parameter_generator(args.pgen)
+    else:
+        parameters = spec.get_parameters()
 
     # Set up the output directory.
     out_dir = environment.remove("OUTPUT_PATH")

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -119,7 +119,7 @@ def load_parameter_generator(path):
             LOGGER.debug("Using Python 2 imp library...")
             f = imp.load_source("custom_gen", path)
             return f.get_custom_generator()
-    except Exception, e:
+    except Exception as e:
         LOGGER.exception(str(e))
         raise e
 

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -88,6 +88,42 @@ def cancel_study(args):
     return 0
 
 
+def load_parameter_generator(path):
+    """
+    Import and load custom parameter Python files.
+
+    :param path: Path to a Python file containing the function
+    'get_custom_generator()'
+    :returns: A populated ParameterGenerator instance.
+    """
+    path = os.path.abspath(path)
+    LOGGER.info("Loading custom parameter generator from '%s'", path)
+    try:
+        # Python 3.5
+        import importlib.util
+        LOGGER.debug("Using Python 3.5 importlib...")
+        spec = importlib.util.spec_from_file_location("custom_gen", path)
+        f = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(f)
+        return f.get_custom_generator()
+    except ImportError:
+        try:
+            # Python 3.3
+            from importlib.machinery import SourceFileLoader
+            LOGGER.debug("Using Python 3.4 SourceFileLoader...")
+            f = SourceFileLoader("custom_gen", path).load_module()
+            return f.get_custom_generator()
+        except ImportError:
+            # Python 2
+            import imp
+            LOGGER.debug("Using Python 2 imp library...")
+            f = imp.load_source("custom_gen", path)
+            return f.get_custom_generator()
+    except Exception, e:
+        LOGGER.exception(str(e))
+        raise e
+
+
 def run_study(args):
     """Run a Maestro study."""
     # Load the Specification

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -266,6 +266,10 @@ def setup_argparser():
     run.add_argument("-d", "--dryrun", action="store_true", default=False,
                      help="Generate the directory structure and scripts for a "
                      "study but do not launch it. [Default: %(default)s]")
+    run.add_argument("-p", "--pgen", type=str,
+                     help="Path to a Python code file containing a function "
+                     "that returns a custom filled ParameterGenerator"
+                     "instance.")
     run.add_argument("-o", "--out", type=str,
                      help="Output path to place study in. [NOTE: overrides "
                      "OUTPUT_PATH in the specified specification]")

--- a/samples/parameterization/custom_generator.py
+++ b/samples/parameterization/custom_generator.py
@@ -1,0 +1,21 @@
+"""An example file that produces a custom ParameterGenerator"""
+
+from maestrowf.datastructures.core import ParameterGenerator
+
+
+def get_custom_generator():
+    """
+    Create a custom populated ParameterGenerator.
+
+    :returns: A ParameterGenerator populated with parameters.
+    """
+    p_gen = ParameterGenerator()
+    key = "TEST"
+    names = ["test1", "test2", "test3", "test4", "test5"]
+    values = ["1", "2", "3", "4", "5"]
+    label = "TEST.{}"
+
+    for i in range(0, len(names)):
+        p_gen.add_parameter(key, values[i], label, names[i])
+
+    return p_gen

--- a/samples/parameterization/custom_generator.py
+++ b/samples/parameterization/custom_generator.py
@@ -1,4 +1,4 @@
-"""An example file that produces a custom ParameterGenerator"""
+"""An example file that produces a custom ParameterGenerator."""
 
 from maestrowf.datastructures.core import ParameterGenerator
 

--- a/samples/parameterization/lulesh_custom_gen.py
+++ b/samples/parameterization/lulesh_custom_gen.py
@@ -20,18 +20,16 @@ def get_custom_generator():
             "label": "TRIAL.%%"
         },
         "SIZE": {
-            "values": [10, 10, 10, 20, 20, 20, 20],
+            "values": [10, 10, 10, 20, 20, 20, 30, 30, 30],
             "label": "SIZE.%%"
         },
         "ITERATIONS": {
             "values": [10, 20, 30, 10, 20, 30, 10, 20, 30],
             "label": "ITERATIONS.%%"
-        },
+        }
     }
 
     for key, value in params.items():
-        label = value["label"]
-        for v in value["values"]:
-            p_gen.add_parameter(key, v, label)
+        p_gen.add_parameter(key, value["values"], value["label"])
 
     return p_gen

--- a/samples/parameterization/lulesh_custom_gen.py
+++ b/samples/parameterization/lulesh_custom_gen.py
@@ -1,0 +1,37 @@
+"""An example file that produces a custom parameters for the LULESH example."""
+
+from maestrowf.datastructures.core import ParameterGenerator
+
+
+def get_custom_generator():
+    """
+    Create a custom populated ParameterGenerator.
+
+    This function recreates the exact same parameter set as the sample LULESH
+    specifications. The point of this file is to present an example of how to
+    generate custom parameters.
+
+    :returns: A ParameterGenerator populated with parameters.
+    """
+    p_gen = ParameterGenerator()
+    params = {
+        "TRIAL": {
+            "values": [i for i in range(1, 10)],
+            "label": "TRIAL.%%"
+        },
+        "SIZE": {
+            "values": [10, 10, 10, 20, 20, 20, 20],
+            "label": "SIZE.%%"
+        },
+        "ITERATIONS": {
+            "values": [10, 20, 30, 10, 20, 30, 10, 20, 30],
+            "label": "ITERATIONS.%%"
+        },
+    }
+
+    for key, value in params.items():
+        label = value["label"]
+        for v in value["values"]:
+            p_gen.add_parameter(key, v, label)
+
+    return p_gen


### PR DESCRIPTION
This PR adds the ability for a user to use custom code for generating parameters. In all cases, metadata about parameters is now dumped. In order to use this feature, a user simply uses the command line ```maestro run --pgen <path to .py> <path to study YAML>```. Within the file specified by the ```--pgen``` flag, the function `get_custom_generator()` must be defined and must return a `ParameterGenerator` instance.