### PR TITLE
Correction to a bug for attempting a restart when a restart isn't specified.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -733,10 +733,16 @@ class ExecutionGraph(DAG):
                     else:
                         logger.info("'%s' timed out, but cannot be restarted."
                                     " Marked as TIMEDOUT.", name)
+                        # Mark that the step ended due to TIMEOUT.
                         record.mark_end(State.TIMEDOUT)
+                        # Remove from in progress since it no longer is.
                         self.in_progress.remove(name)
+                        # Add the subtree to the clean up steps
                         cleanup_steps.update(self.bfs_subtree(name)[0])
+                        # Remove the current step, clean up is used to mark
+                        # steps definitively as failed.
                         cleanup_steps.remove(name)
+                        # Add the current step to failed.
                         self.failed_steps.add(name)
 
                 elif status == State.HWFAILURE:


### PR DESCRIPTION
Previously, the conductor made the assumption that if a step timed out that the user specified a way to restart. That assumption does not necessarily hold because a restart can not be specified. This PR corrects that assumption by adding the capability to check if a record can be restarted and does the appropriate book keeping if it cannot be.