### PR TITLE
Throttled workflows push steps into the ready queue multiple times.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -828,7 +828,13 @@ class ExecutionGraph(DAG):
         else:
             # Compute the number of available slots we have for execution.
             _available = self._submission_throttle - len(self.in_progress)
+            # Available slots should never be negative, but on the off chance
+            # we are in a slot deficit, then we will just say none are free.
             _available = max(0, _available)
+            # Now, we need to take the min of the length of the queue and the
+            # computed number of slots. We could have free slots, but have less
+            # in the queue.
+            _available = min(_available, len(self.ready_steps))
             logger.info("Found %d available slots...", _available)
 
         for i in range(0, _available):

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -89,6 +89,7 @@ class _StepRecord(object):
                     self.script, self.restart_script, self.to_be_scheduled)
 
     def execute(self, adapter):
+        self.mark_submitted()
         retcode, jobid = self._execute(adapter, self.script)
 
         if retcode == SubmissionCode.OK:
@@ -567,7 +568,6 @@ class ExecutionGraph(DAG):
                 # Generate the script for execution on the fly.
                 record.setup_workspace()    # Generate the workspace.
                 record.generate_script(adapter, self._tmp_dir)
-                record.mark_submitted()
                 retcode = record.execute(adapter)
             # Otherwise, it's a restart.
             else:

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -140,7 +140,7 @@ class _StepRecord(object):
             self._submit_time = datetime.now()
         else:
             logger.warning(
-                "Cannot set the submission time of '%s' because it has"
+                "Cannot set the submission time of '%s' because it has "
                 "already been set.", self.name
             )
 
@@ -753,7 +753,7 @@ class ExecutionGraph(DAG):
                                    "resubmit step '%s'.", name)
                     # We can just let the logic below handle submission with
                     # everything else.
-                    self.ready_steps.append(record)
+                    self.ready_steps.append(name)
 
                 elif status == State.FAILED:
                     logger.warning(
@@ -798,23 +798,23 @@ class ExecutionGraph(DAG):
 
                 logger.debug(
                     "Unfulfilled dependencies: %s",
-                    self._dependencies[record.name])
+                    self._dependencies[key])
 
                 s_completed = filter(
                     lambda x: x in self.completed_steps,
-                    self._dependencies[record.name])
-                self._dependencies[record.name] = \
-                    self._dependencies[record.name] - set(s_completed)
+                    self._dependencies[key])
+                self._dependencies[key] = \
+                    self._dependencies[key] - set(s_completed)
                 logger.debug(
                     "Completed dependencies: %s\n"
                     "Remaining dependencies: %s",
-                    s_completed, self._dependencies[record.name])
+                    s_completed, self._dependencies[key])
 
                 # If the gating dependencies set is empty, we can execute.
-                if not self._dependencies[record.name]:
+                if not self._dependencies[key]:
                     if key not in self.ready_steps:
                         logger.debug("All dependencies completed. Staging.")
-                        self.ready_steps.append(record)
+                        self.ready_steps.append(key)
                     else:
                         logger.debug("Already staged. Passing.")
                         continue
@@ -833,7 +833,7 @@ class ExecutionGraph(DAG):
 
         for i in range(0, _available):
             # Pop the record and execute using the helper method.
-            _record = self.ready_steps.popleft()
+            _record = self.values[self.ready_steps.popleft()]
 
             # If we get to this point and we've cancelled, cancel the record.
             if self.is_canceled:


### PR DESCRIPTION
Originally from https://github.com/LLNL/maestrowf/pull/133#issuecomment-413932611:

@jsemler -- Alright, after a good bit of digging around, I think I've narrowed the bug down. I apologize if this explanation is somewhat convoluted, but I'll do what I can to make it clear.

In the `ExecutionGraph` method `execute_ready_steps`, there are a number of back end sets that track various aspects of execution, including failed steps, in progress steps, completed steps, dependency completions, and various other things (which for this discussion aren't important). The major thing that gets tracked are the ready steps which are in a `deque` object. When a step is deemed to be ready, its `StepRecord` object is pushed to the `ready_steps` queue. However, in the `execute_ready_steps` method, the following code currently exists (line 785 in executiongraph.py):

```
# If the gating dependencies set is empty, we can execute.
if not self._dependencies[record.name]:
if key not in self.ready_steps:
    logger.debug("All dependencies completed. Staging.")
    self.ready_steps.append(record)
else:
    logger.debug("Already staged. Passing.")
    continue
```

I noticed that in the log you provided that steps that were repeated would always trigger the "All dependencies completed. Staging." log message and I never saw the passing message in the `else`. That's likely because when I refactored and cleaned up the method last time, I made the transition to tracking records by their name instead of the object in order to clean up a lot of the `record.name` referencing I was doing. Somewhere along the way, it looks like I forgot to transition the `ready_steps` queue to the same structure and so it goes to check if the key is in the `deque` and never finds it since it's a queue of `StepRecord` objects.

I don't expect the fix to this will be difficult, so I'll try and have it completed today. We can still go through it if you'd like.

Edit: As an extra note, I think this issue only appears when throttling because that is the only time you'll have steps queued that are still in the `INITIALIZED` state. If not throttling, you'd never run into a duplicate in the queue since those steps would be in at least `PENDING` when submitted.