### PR TITLE
Rework the LocalScriptAdapter to more closely mimic an actual scheduler.

### DIFF
--- a/maestrowf/datastructures/utilities/executionpool.py
+++ b/maestrowf/datastructures/utilities/executionpool.py
@@ -1,0 +1,38 @@
+"""A module for containing data structures for process pool management"""
+
+import logging
+from Queue import Queue
+from threading import Event, Lock, Thread
+
+from maestrowf.abstracts import Singleton
+from maestrowf.utils import start_process
+
+
+class ExecutionPool(Singleton, Thread):
+    """A class that manages the execution of multiple processes."""
+
+    def __init__(self, limit=0, env=None):
+        # A map of process id to running process.
+        self._status_reg = {}
+        self._proc_queue = Queue()
+        self._env = env
+
+        # Events for controlling ExecutionPool threading.
+        self._stop = Event()
+
+    def queue_process(self, path, cwd=None):
+        # Simply
+        self._proc_queue.put((path, cwd))
+
+    def poll_processes(self, pids):
+        for entry in self._status_reg.items():
+            pass
+
+    def kill_processes(self, pids):
+        pass
+
+    def stop(self):
+        self._stop.set()
+
+    def run(self):
+        pass

--- a/maestrowf/datastructures/utilities/readwriterlock.py
+++ b/maestrowf/datastructures/utilities/readwriterlock.py
@@ -1,0 +1,62 @@
+import logging
+from threading import Lock
+
+
+class ReadWriterLock(object):
+
+    class _WriterWriter(object):
+        def __init__(self, rwlock):
+            self._rwlock = rwlock
+
+        def release(self):
+            self._wlock.release()
+
+        @property
+        def is_locked(self):
+            return self._wlock.locked()
+
+        def __enter__(self):
+            return self.acquire()
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self._rwlock.release("writer")
+
+    class _ReaderInterface(object):
+        def __init__(self, rwlock):
+            self._rwlock = rwlock
+
+        def __enter__(self):
+            return self.acquire()
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self._rwlock.release("reader")
+
+    def __init__(self):
+        # Information relevant for updating reader statuses.
+        self._readers = 0
+        self._read_lock = Lock()
+
+        # Writer lock for exclusive writing.
+        self._write_lock = Lock()
+
+        # General information
+        self._timeout = timeout
+
+    def release(type):
+        type = str(type).lower()
+
+        if type == "reader":
+            with self._read_lock:
+                self._readers -= 1
+        elif type == "writer":
+            self._write_lock.release()
+        else:
+            msg = "A type other than reader or writer specified (type={})" \
+                  .format(type)
+            raise ValueError(msg)
+
+    def acquire_write(self, timeout=-1. blocking=True):
+
+
+    def acquire_read(self, timeout=-1, blocking=True):
+        pass


### PR DESCRIPTION
NOTE: This PR is turning into a somewhat extensive change, so I wanted to throw up a PR to better track and discuss the changes that are happening and maybe see if anyone had any thoughts.

This PR captures all related changes to the `LocalScriptAdapter` that are aiming to have it mimic an actual scheduler. The current plan is to implement a threaded `ExecutionPool` that actively updates and stores records of locally executing processes kicked off through the conductor. The conductor can then pass a list of process identifiers to retrieve the status just like it would for the SLURM adapter or any other scheduler. This requires a `Singleton` instance of the `ExecutionPool` which provides the backend lifting for the `LocalScriptAdapter`.  So far, this has necessitated the use of a ReadWrite lock that would lock the backend status structures (again, this is something that any scheduler does automatically).