### PR TITLE
Addition of pargs for passing parameters to custom parameter generation

### DIFF
--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -176,6 +176,12 @@ def run_study(args):
     # Now that we know outpath, set up logging.
     setup_logging(args, output_path, spec.name.replace(" ", "_").lower())
 
+    # Check for pargs without the matching pgen
+    if args.pargs and not args.pgen:
+        msg = "Cannot use the 'pargs' parameter without specifying a 'pgen'!"
+        LOGGER.exception(msg)
+        raise ArgumentError(msg)
+
     # Handle loading a custom ParameterGenerator if specified.
     if args.pgen:
         # 'pgen_args' has a default of an empty list, which should translate

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -209,3 +209,19 @@ def ping_url(url):
     else:
         response.read()
         return
+
+
+def create_dictionary(list_keyvalues, token=":"):
+    """
+    Create a dictionary from a list of key-value pairs.
+
+    :param list_keyvalues: List of token separates key-values.
+    :param token: The token to split each key-value by.
+    :returns: A dictionary containing the key-value pairings in list_keyvalues.
+    """
+    _dict = {}
+    for item in list_keyvalues:
+        key, value = [i.strip() for i in item.split(token, 1)]
+        _dict[key] = value
+
+    return _dict

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -221,7 +221,14 @@ def create_dictionary(list_keyvalues, token=":"):
     """
     _dict = {}
     for item in list_keyvalues:
-        key, value = [i.strip() for i in item.split(token, 1)]
-        _dict[key] = value
+        try:
+            key, value = [i.strip() for i in item.split(token, 1)]
+            _dict[key] = value
+        except ValueError:
+            msg = "'{}' is not capable of being split by the token '{}'. " \
+                  "Verify that all other parameters are formatted properly." \
+                  .format(item, token)
+            LOGGER.exception(msg)
+            raise ValueError(msg)
 
     return _dict

--- a/samples/parameterization/lulesh_montecarlo_args.py
+++ b/samples/parameterization/lulesh_montecarlo_args.py
@@ -1,0 +1,42 @@
+"""An example file that produces a custom parameters for the LULESH example."""
+
+from random import randint
+
+from maestrowf.datastructures.core import ParameterGenerator
+
+
+def get_custom_generator(**kwargs):
+    """
+    Create a custom populated ParameterGenerator.
+
+    This function recreates the exact same parameter set as the sample LULESH
+    specifications. The point of this file is to present an example of how to
+    generate custom parameters.
+
+    :params kwargs: A dictionary of keyword arguments this function uses.
+    :returns: A ParameterGenerator populated with parameters.
+    """
+    p_gen = ParameterGenerator()
+    trials = int(kwargs.get("trials"))
+    size_min = int(kwargs.get("smin"))
+    size_max = int(kwargs.get("smax"))
+    iterations = int(kwargs.get("iter"))
+    params = {
+        "TRIAL": {
+            "values": [i for i in range(1, trials)],
+            "label": "TRIAL.%%"
+        },
+        "SIZE": {
+            "values": [randint(size_min, size_max) for i in range(1, trials)],
+            "label": "SIZE.%%"
+        },
+        "ITERATIONS": {
+            "values": [iterations for i in range(1, trials)],
+            "label": "ITERATIONS.%%"
+        }
+    }
+
+    for key, value in params.items():
+        p_gen.add_parameter(key, value["values"], value["label"])
+
+    return p_gen

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(name='maestrowf',
       description='A tool and library for specifying and conducting general '
       'workflows.',
-      version='1.1.4dev',
+      version='1.1.4dev1',
       author='Francesco Di Natale',
       author_email='dinatale3@llnl.gov',
       url='https://github.com/llnl/maestrowf',


### PR DESCRIPTION
This PR adds the functionality to pass arguments to a user specified parameter generating code (the `pgen` CLI parameter). A user can specify multiple `--pargs` command line options to pass in multiple parameters. There is now an example of a randomized "Monte Carlo"-esque LULESH example that accepts parameters.

```maestro run -p ./samples/parameterization/lulesh_montecarlo_args.py --pargs "trials:50" --pargs "smin:10" --pargs "smax:50" --pargs "iter:100" ./samples/lulesh/lulesh_sample1_macosx.yaml```

The command line above runs an example where the size of a simulation is randomly generated between a min of 10 and a max of 50 over 50 trials with each being run for 100 iterations.