### PR TITLE
Removal of _stage_linear since it is now not needed.

### DIFF
--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -392,7 +392,7 @@ class Study(DAG):
             use_tmp, hash_ws
         )
 
-    def _stage_parameterized(self, dag):
+    def _stage(self, dag):
         """
         Set up the ExecutionGraph of a parameterized study.
 
@@ -794,11 +794,4 @@ class Study(DAG):
         dag.add_description(**self.description)
         dag.log_description()
 
-        # We have two cases:
-        # 1. Parameterized workflows
-        # 2. A linear, execute as specified workflow
-        # NOTE: This scheme could be how we handle derived use cases.
-        if self.parameters:
-            return self._out_path, self._stage_parameterized(dag)
-        else:
-            return self._out_path, self._stage_linear(dag)
+        return self._out_path, self._stage(dag)

--- a/samples/lulesh/lulesh_sample1_macosx_linear.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx_linear.yaml
@@ -1,0 +1,70 @@
+description:
+    name: lulesh sample1
+    description: A sample LULESH study that downloads, builds, and runs a parameter study of varying problem sizes and iterations.
+
+env:
+    variables:
+        OUTPUT_PATH: ./sample_output/lulesh
+        SIZE: 10
+        ITERATIONS: 20
+        TRIAL: 1
+
+    labels:
+        outfile: SIZE.$(SIZE).ITER.$(ITERATIONS).log
+
+    dependencies:
+      git:
+        - name: LULESH
+          path: $(OUTPUT_PATH)
+          url: https://github.com/LLNL/LULESH.git
+
+study:
+    - name: make-lulesh
+      description: Build the serial version of LULESH.
+      run:
+          cmd: |
+            cd $(LULESH)
+            sed -i "" 's/^CXX = $(MPICXX)/CXX = $(SERCXX)/' ./Makefile
+            sed -i "" 's/^CXXFLAGS = -g -O3 -fopenmp/#CXXFLAGS = -g -O3 -fopenmp/' ./Makefile
+            sed -i "" 's/^#LDFLAGS = -g -O3/LDFLAGS = -g -O3/' ./Makefile
+            sed -i "" 's/^LDFLAGS = -g -O3 -fopenmp/#LDFLAGS = -g -O3 -fopenmp/' ./Makefile
+            sed -i "" 's/^#CXXFLAGS = -g -O3 -I/CXXFLAGS = -g -O3 -I/' ./Makefile
+            make clean
+            make
+          depends: []
+
+    - name: run-lulesh
+      description: Run LULESH.
+      run:
+          cmd: |
+            $(LULESH)/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p > $(outfile)
+          depends: [make-lulesh]
+
+    - name: post-process-lulesh
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "Unparameterized step with Parameter Independent dependencies." >> out.log
+            echo $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) > ls.log
+          depends: [run-lulesh]
+
+    - name: post-process-lulesh-trials
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "Parameterized step that has Parameter Independent dependencies" >> out.log
+            echo "TRIAL = $(TRIAL)" >> out.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) > out.log
+          depends: [run-lulesh]
+
+    - name: post-process-lulesh-size
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "Parameterized step that has Parameter Independent dependencies" >> out.log
+            echo "SIZE = $(SIZE)" >> out.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) | grep SIZE.$(SIZE) >> out.log
+          depends: [run-lulesh]

--- a/samples/lulesh/lulesh_sample1_unix_linear.yaml
+++ b/samples/lulesh/lulesh_sample1_unix_linear.yaml
@@ -1,0 +1,70 @@
+description:
+    name: lulesh sample1
+    description: A sample LULESH study that downloads, builds, and runs a parameter study of varying problem sizes and iterations.
+
+env:
+    variables:
+        OUTPUT_PATH: ./sample_output/lulesh
+        SIZE: 10
+        ITERATIONS: 20
+        TRIAL: 1
+
+    labels:
+        outfile: SIZE.$(SIZE).ITER.$(ITERATIONS).log
+
+    dependencies:
+      git:
+        - name: LULESH
+          path: $(OUTPUT_PATH)
+          url: https://github.com/LLNL/LULESH.git
+
+study:
+    - name: make-lulesh
+      description: Build the serial version of LULESH.
+      run:
+          cmd: |
+            cd $(LULESH)
+            sed -i 's/^CXX = $(MPICXX)/CXX = $(SERCXX)/' ./Makefile
+            sed -i 's/^CXXFLAGS = -g -O3 -fopenmp/#CXXFLAGS = -g -O3 -fopenmp/' ./Makefile
+            sed -i 's/^#LDFLAGS = -g -O3/LDFLAGS = -g -O3/' ./Makefile
+            sed -i 's/^LDFLAGS = -g -O3 -fopenmp/#LDFLAGS = -g -O3 -fopenmp/' ./Makefile
+            sed -i 's/^#CXXFLAGS = -g -O3 -I/CXXFLAGS = -g -O3 -I/' ./Makefile
+            make clean
+            make
+          depends: []
+
+    - name: run-lulesh
+      description: Run LULESH.
+      run:
+          cmd: |
+            $(LULESH)/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p > $(outfile)
+          depends: [make-lulesh]
+
+    - name: post-process-lulesh
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "Unparameterized step with Parameter Independent dependencies." >> out.log
+            echo $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) > ls.log
+          depends: [run-lulesh]
+
+    - name: post-process-lulesh-trials
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "Parameterized step that has Parameter Independent dependencies" >> out.log
+            echo "TRIAL = $(TRIAL)" >> out.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) > out.log
+          depends: [run-lulesh]
+
+    - name: post-process-lulesh-size
+      description: Post process all LULESH results.
+      run:
+          cmd: |
+            echo "Parameterized step that has Parameter Independent dependencies" >> out.log
+            echo "SIZE = $(SIZE)" >> out.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) | grep SIZE.$(SIZE) >> out.log
+          depends: [run-lulesh]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(name='maestrowf',
       description='A tool and library for specifying and conducting general '
       'workflows.',
-      version='1.1.4dev1.0',
+      version='1.1.4dev1.1',
       author='Francesco Di Natale',
       author_email='dinatale3@llnl.gov',
       url='https://github.com/llnl/maestrowf',


### PR DESCRIPTION
@tadesautels and @jsemler both ran into the same bug related to linear study staging. It seems that the previous `_stage_linear` in the `Study` class was outdated since the new `_stage_parameterized` was introduced. It seems like it was entirely an oversight, but it now seems like it's redundant since the parameterized staging is general enough to handle both cases. The simplest solution to this bug seems to just move `_stage_parameterized` to be the general solution and to remove `_stage_linear` entirely.

@tadesautels and @jsemler -- Can you two confirm that this fix works for the studies that triggered your bug?