### PR TITLE
Correction to fix the format of output status time to avoid a comma that breaks printing.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -14,7 +14,7 @@ from maestrowf.abstracts.enums import JobStatusCode, State, SubmissionCode, \
 from maestrowf.datastructures.dag import DAG
 from maestrowf.datastructures.environment import Variable
 from maestrowf.interfaces import ScriptAdapterFactory
-from maestrowf.utils import create_parentdir
+from maestrowf.utils import create_parentdir, get_duration
 
 logger = logging.getLogger(__name__)
 SOURCE = "_source"
@@ -195,10 +195,10 @@ class _StepRecord(object):
         """Compute the elapsed time of the record (includes queue wait)."""
         if self._submit_time and self._end_time:
             # Return the total elapsed time.
-            return str(self._end_time - self._submit_time)
+            return get_duration(self._end_time - self._submit_time)
         elif self._submit_time and self.status == State.RUNNING:
             # Return the current elapsed time.
-            return str(datetime.now() - self._submit_time)
+            return get_duration(datetime.now() - self._submit_time)
         else:
             return "--:--:--"
 
@@ -211,10 +211,10 @@ class _StepRecord(object):
         """
         if self._start_time and self._end_time:
             # If start and end time is set -- calculate run time.
-            return str(self._end_time - self._start_time)
+            return get_duration(self._end_time - self._start_time)
         elif self._start_time and not self.status == State.RUNNING:
             # If start time but no end time, calculate current duration.
-            return str(datetime.now() - self._start_time)
+            return get_duration(datetime.now() - self._start_time)
         else:
             # Otherwise, return an uncalculated marker.
             return "--:--:--"

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -41,9 +41,24 @@ import time
 LOGGER = logging.getLogger(__name__)
 
 
+def get_duration(time_delta):
+    """
+    Covert durations to HH:MM:SS format.
+
+    :params time_delta: A time difference in datatime format.
+    :returns: A formatted string in HH:MM:SS
+    """
+    duration = time_delta.total_seconds()
+    hours = int(duration / 3600)
+    minutes = int(duration % 3600 / 60)
+    seconds = int((duration % 3600) % 60)
+
+    return "{:02d}:{:02d}:{:02d}".format(hours, minutes, seconds)
+
+
 def generate_filename(path, append_time=True):
     """
-    Utility function for generating a non-conflicting file name.
+    Generate a non-conflicting file name.
 
     :param path: Path to file.
     :param append_time: Setting to append a timestamp.

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -54,7 +54,7 @@ def get_duration(time_delta):
     minutes = int((duration % 86400 % 3600) / 60)
     seconds = int((duration % 86400 % 3600) % 60)
 
-    return "{:d} days {:02d}h:{:02d}m:{:02d}s" \
+    return "{:d}d:{:02d}h:{:02d}m:{:02d}s" \
            .format(days, hours, minutes, seconds)
 
 

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -49,11 +49,13 @@ def get_duration(time_delta):
     :returns: A formatted string in HH:MM:SS
     """
     duration = time_delta.total_seconds()
-    hours = int(duration / 3600)
-    minutes = int(duration % 3600 / 60)
-    seconds = int((duration % 3600) % 60)
+    days = int(duration / 86400)
+    hours = int((duration % 86400) / 3600)
+    minutes = int((duration % 86400 % 3600) / 60)
+    seconds = int((duration % 86400 % 3600) % 60)
 
-    return "{:02d}:{:02d}:{:02d}".format(hours, minutes, seconds)
+    return "{:02d} days {:02d}:{:02d}:{:02d}" \
+           .format(days, hours, minutes, seconds)
 
 
 def generate_filename(path, append_time=True):

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -54,7 +54,7 @@ def get_duration(time_delta):
     minutes = int((duration % 86400 % 3600) / 60)
     seconds = int((duration % 86400 % 3600) % 60)
 
-    return "{:02d} days {:02d}:{:02d}:{:02d}" \
+    return "{:d} days {:02d}h:{:02d}m:{:02d}s" \
            .format(days, hours, minutes, seconds)
 
 


### PR DESCRIPTION
Fixes #159 -- long running jobs can reach the day range and breaks the formatted print because the time difference contains a comma.