### PR TITLE
do not overwrite log file in the lulesh unix example

### DIFF
--- a/samples/lulesh/lulesh_sample1_unix.yaml
+++ b/samples/lulesh/lulesh_sample1_unix.yaml
@@ -53,7 +53,7 @@ study:
             echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "TRIAL = $(TRIAL)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
-            ls $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh_*]
 
     - name: post-process-lulesh-size


### PR DESCRIPTION
Last line to the out.log in post-process-lulesh-trials was overwriting the log file, needed a `>>` instead of a `>`
Signed-off-by: Peter Robinson <robinson96@llnl.gov>