### PR TITLE
Introduction of user defined post steps

### DIFF
--- a/maestrowf/abstracts/enums/__init__.py
+++ b/maestrowf/abstracts/enums/__init__.py
@@ -30,20 +30,29 @@
 """Package for providing enumerations for interfaces"""
 from enum import Enum
 
-__all__ = ("JobStatusCode", "State", "SubmissionCode", "StudyStatus")
+__all__ = (
+    "JobStatusCode",
+    "PostCode",
+    "State",
+    "SubmissionCode",
+    "StudyStatus"
+)
 
 
 class SubmissionCode(Enum):
+    """Return states during submission."""
     OK = 0
     ERROR = 1
 
 
 class CancelCode(Enum):
+    """Return states during cancellation."""
     OK = 0
     ERROR = 1
 
 
 class JobStatusCode(Enum):
+    """Return states when polling for job status."""
     OK = 0
     NOJOBS = 1
     ERROR = 2

--- a/maestrowf/abstracts/enums/__init__.py
+++ b/maestrowf/abstracts/enums/__init__.py
@@ -74,6 +74,7 @@ class State(Enum):
     TIMEDOUT = 10
     UNKNOWN = 11
     CANCELLED = 12
+    NOOP = 13
 
 
 class StudyStatus(Enum):


### PR DESCRIPTION
This PR relates to issue #98 -- the addition of pre and post steps. Some initial exploration has revealed that the addition of post steps will be a non-trivial effort so I'm making this PR the base PR for other branches that will iteratively refactor and add the necessary functionality to build this up. So far here's what's holding up the feature:

- The `ScriptAdapter` and `SchedulerScriptAdapter` abstract interfaces are cumbersome. The `get_scheduler_command` method, for example, takes in a step as its only argument and returns a Boolean with a path to the script that executes the command and a path to the restart script (if the step specifies a restart). There is no general way to simply generate a script currently other than refactoring or adding more returns to the `get_scheduler_command` method.
- Script generation is too coupled with higher level information. The `LocalScriptAdapter` has the same underlying structure as any other `SchedulerScriptAdapter` and because of this requires things like a header. A little more generalization is needed so that an adapter's functionality should get more specific information passed to it instead of a whole step.
- The `SchedulerScriptAdapter` really should be split up into a batch interface and a script interface and would help with the first bullet. The division of responsibility would open up the ability to generate simple scripts without the need of extra information and could be used to generate scripts as needed without having monolithic generation methods.

The split of responsibilities is already being started in a new branch `post_steps/adapter_refactor`, which will lead to tweaks to all the adapters and then the addition of general script generation to support post steps.