### PR TITLE
Change to transition adapter returns to Record objects.

### DIFF
--- a/maestrowf/abstracts/containers/__init__.py
+++ b/maestrowf/abstracts/containers/__init__.py
@@ -1,0 +1,50 @@
+###############################################################################
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory
+# Written by Francesco Di Natale, dinatale3@llnl.gov.
+#
+# LLNL-CODE-734340
+# All rights reserved.
+# This file is part of MaestroWF, Version: 1.0.0.
+#
+# For details, see https://github.com/LLNL/maestrowf.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+###############################################################################
+
+"""Module that defines containers for storing various types of information."""
+
+
+class Record(object):
+    """A container class for holding general information."""
+
+    def __init__(self):
+        """Initialize an empty Record."""
+        self._info = {}
+
+    def get(self, key, default=None):
+        """
+        Get information by key in a record.
+
+        :param key: The key to look up in a Record's stored information.
+        :param default: The default value to return if the key is not found
+        (Default: None).
+        :returns: The information labeled by parameter key. Default if key does
+        not exist.
+        """
+        return self._info.get(key, default)

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -919,19 +919,18 @@ class ExecutionGraph(DAG):
         adapter = adapter(**self._adapter)
 
         # cancel our jobs
-        retcode = adapter.cancel_jobs(joblist)
+        crecord = adapter.cancel_jobs(joblist)
         self.is_canceled = True
 
-        if retcode == CancelCode.OK:
+        if crecord.cancel_status == CancelCode.OK:
             logger.info("Successfully requested to cancel all jobs.")
-            return retcode
-        elif retcode == CancelCode.ERROR:
-            logger.error("Failed to cancel jobs.")
-            return retcode
+        elif crecord.cancel_status == CancelCode.ERROR:
+            logger.error(
+                "Failed to cancel jobs. (Code = %s)", crecord.return_code)
         else:
-            msg = "Unknown Error (Code = {retcode})".format(retcode)
-            logger.error(msg)
-            return retcode
+            logger.error("Unknown Error (Code = %s)", crecord.return_code)
+
+        return crecord.cancel_status
 
     def cleanup(self):
         """Clean up output produced by the ExecutionGraph."""

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -119,14 +119,16 @@ class _StepRecord(object):
 
     def _execute(self, adapter, script):
         if self.to_be_scheduled:
-            retcode, jobid = adapter.submit(
+            srecord = adapter.submit(
                 self.step, script, self.workspace.value)
         else:
             self.mark_running()
             ladapter = ScriptAdapterFactory.get_adapter("local")()
-            retcode, jobid = ladapter.submit(
+            srecord = ladapter.submit(
                 self.step, script, self.workspace.value)
 
+        retcode = srecord.submission_code
+        jobid = srecord.job_identifier
         return retcode, jobid
 
     def mark_submitted(self):

--- a/maestrowf/interfaces/script/__init__.py
+++ b/maestrowf/interfaces/script/__init__.py
@@ -83,17 +83,38 @@ class SubmissionRecord(Record):
         """
         return self._info["retcode"]
 
+    def add_info(self, key, value):
+        """
+        Set additional informational key-value information.
+
+        :param key: Record key identifying data.
+        :param value: Data to be recorded.
+        """
+        self._info[key] = value
+
+    def get(self, key, default=None):
+        """
+        Retrieve the value labeled by the specified key.
+
+        :param key: Key to retrieve.
+        :param default: Default value if parameter key is not found. Default
+        is None.
+        :returns: The data labeled by key, otherwise default if key is not
+        found.
+        """
+
 
 class CancellationRecord(Record):
     """A container for data returned from a scheduler cancellation call."""
 
-    def __init__(self, retcode):
+    def __init__(self, cancel_status, retcode):
         """Initialize an empty CancellationRecord."""
         self._status = {
             CancelCode.OK:      set(),
-            CancelCode.Error:   set(),
+            CancelCode.ERROR:   set(),
         }   # Map of cancellation status to job set.
         self._retcode = retcode
+        self._cstatus = cancel_status
 
     def add_status(self, jobid, cancel_status):
         """
@@ -112,6 +133,11 @@ class CancellationRecord(Record):
     @property
     def cancel_status(self):
         """Get the high level CancelCode status."""
+        return self._cstatus
+
+    @property
+    def return_code(self):
+        """Get the return code from the cancel command."""
         return self._retcode
 
     def lookup_status(self, cancel_status):

--- a/maestrowf/interfaces/script/__init__.py
+++ b/maestrowf/interfaces/script/__init__.py
@@ -83,6 +83,7 @@ class SubmissionRecord(Record):
         """
         return self._info["retcode"]
 
+<<<<<<< 0972ffc3ec7a2067f392adc7746d63cde33eb76f
     def add_info(self, key, value):
         """
         Set additional informational key-value information.

--- a/maestrowf/interfaces/script/__init__.py
+++ b/maestrowf/interfaces/script/__init__.py
@@ -32,7 +32,7 @@ __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 
 from maestrowf.abstracts.containers import Record
-from maestrowf.abstracts.enums import SubmissionCode
+from maestrowf.abstracts.enums import CancelCode, SubmissionCode
 
 
 class SubmissionRecord(Record):
@@ -82,3 +82,25 @@ class SubmissionRecord(Record):
         from submission.
         """
         return self._info["retcode"]
+
+
+class CancellationRecord(Record):
+    """A container for data returned from a scheduler cancellation call."""
+
+    def __init__(self):
+        """Initialize an empty CancellationRecord."""
+        self._status = {}   # Map of job identifier to its own status.
+
+    def add_status(self, jobid, cancel_status):
+        """
+        Add the cancellation status for a single job to a record.
+
+        :param jobid: Unique job identifier for the job status to be added.
+        :param cancel_status: CancelCode designating how cancellation
+        terminated.
+        """
+        if not isinstance(cancel_status, CancelCode):
+            raise TypeError(
+                "Parameter 'cancel_code' must be of type 'CancelCode'. "
+                "Received type '%s' instead.", type(cancel_status))
+        self._status[jobid] = cancel_status

--- a/maestrowf/interfaces/script/__init__.py
+++ b/maestrowf/interfaces/script/__init__.py
@@ -26,4 +26,59 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 ###############################################################################
+
+"""Module for interfaces that support various schedulers."""
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+
+
+from maestrowf.abstracts.containers import Record
+from maestrowf.abstracts.enums import SubmissionCode
+
+
+class SubmissionRecord(Record):
+    """A container for data about return state upon scheduler submission."""
+
+    def __init__(self, jobid, subcode, retcode):
+        """
+        Initialize a new SubmissionRecord.
+
+        :param jobid: The assigned job identifier for this record.
+        :param retcode: The submission code returned by the scheduler submit.
+        """
+        self._subcode = subcode
+        self._info = {}
+
+        if subcode == SubmissionCode.OK:
+            # If we got an error, ignore the job identifier.
+            self._info["jobid"] = jobid
+        self._info["retcode"] = retcode
+
+    @property
+    def job_identifier(self):
+        """
+        Property for the job identifier for the record.
+
+        :returns: A string representing the job identifer assigned by the
+        scheduler.
+        """
+        return self._info.get("jobid", None)
+
+    @property
+    def submission_code(self):
+        """
+        Property for submission state for the record.
+
+        :returns: A SubmissionCode enum representing the state of the
+        submission call.
+        """
+        return self._subcode
+
+    @property
+    def return_code(self):
+        """
+        Property for the raw return code returned from submission.
+
+        :returns: An integer representing the state of the raw return code
+        from submission.
+        """
+        return self._info["retcode"]

--- a/maestrowf/interfaces/script/__init__.py
+++ b/maestrowf/interfaces/script/__init__.py
@@ -45,8 +45,8 @@ class SubmissionRecord(Record):
         :param jobid: The assigned job identifier for this record.
         :param retcode: The submission code returned by the scheduler submit.
         """
+        super(SubmissionRecord, self).__init__()
         self._subcode = subcode
-        self._info = {}
 
         if subcode == SubmissionCode.OK:
             # If we got an error, ignore the job identifier.

--- a/maestrowf/interfaces/script/__init__.py
+++ b/maestrowf/interfaces/script/__init__.py
@@ -38,7 +38,7 @@ from maestrowf.abstracts.enums import SubmissionCode
 class SubmissionRecord(Record):
     """A container for data about return state upon scheduler submission."""
 
-    def __init__(self, jobid, subcode, retcode):
+    def __init__(self, subcode, retcode, jobid=-1):
         """
         Initialize a new SubmissionRecord.
 

--- a/maestrowf/interfaces/script/__init__.py
+++ b/maestrowf/interfaces/script/__init__.py
@@ -83,7 +83,6 @@ class SubmissionRecord(Record):
         """
         return self._info["retcode"]
 
-<<<<<<< 0972ffc3ec7a2067f392adc7746d63cde33eb76f
     def add_info(self, key, value):
         """
         Set additional informational key-value information.

--- a/maestrowf/interfaces/script/__init__.py
+++ b/maestrowf/interfaces/script/__init__.py
@@ -92,17 +92,6 @@ class SubmissionRecord(Record):
         """
         self._info[key] = value
 
-    def get(self, key, default=None):
-        """
-        Retrieve the value labeled by the specified key.
-
-        :param key: Key to retrieve.
-        :param default: Default value if parameter key is not found. Default
-        is None.
-        :returns: The data labeled by key, otherwise default if key is not
-        found.
-        """
-
 
 class CancellationRecord(Record):
     """A container for data returned from a scheduler cancellation call."""

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -35,17 +35,17 @@ from maestrowf.abstracts.enums import JobStatusCode, SubmissionCode, \
     CancelCode
 from maestrowf.interfaces.script import CancellationRecord, SubmissionRecord
 from maestrowf.abstracts.interfaces import ScriptAdapter
-from maestrowf.interfaces.script import SubmissionRecord
 from maestrowf.utils import start_process
 
 LOGGER = logging.getLogger(__name__)
 
 
 class LocalScriptAdapter(ScriptAdapter):
-    """A ScriptAdapter class for interfacing for local execution."""
-
     key = "local"
 
+    """
+    A ScriptAdapter class for interfacing for local execution.
+    """
     def __init__(self, **kwargs):
         """
         Initialize an instance of the LocalScriptAdapter.

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -35,6 +35,7 @@ from maestrowf.abstracts.enums import JobStatusCode, SubmissionCode, \
     CancelCode
 from maestrowf.interfaces.script import CancellationRecord, SubmissionRecord
 from maestrowf.abstracts.interfaces import ScriptAdapter
+from maestrowf.interfaces.script import SubmissionRecord
 from maestrowf.utils import start_process
 
 LOGGER = logging.getLogger(__name__)

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -34,6 +34,7 @@ import os
 from maestrowf.abstracts.enums import JobStatusCode, SubmissionCode, \
     CancelCode
 from maestrowf.abstracts.interfaces import ScriptAdapter
+from maestrowf.interfaces.script import SubmissionRecord
 from maestrowf.utils import start_process
 
 LOGGER = logging.getLogger(__name__)
@@ -139,7 +140,7 @@ class LocalScriptAdapter(ScriptAdapter):
 
         if retcode == 0:
             LOGGER.info("Execution returned status OK.")
-            return SubmissionCode.OK, pid
+            return SubmissionRecord(SubmissionCode.OK, retcode, pid)
         else:
             LOGGER.warning("Execution returned an error: %s", str(err))
-            return SubmissionCode.ERROR, pid
+            return SubmissionRecord(SubmissionCode.ERROR, retcode, pid)

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -82,18 +82,14 @@ class LocalScriptAdapter(ScriptAdapter):
         fname = "{}.sh".format(step.name)
         script_path = os.path.join(ws_path, fname)
         with open(script_path, "w") as script:
-            script.write(self._exec)
-            _ = "\n\n{}\n".format(cmd)
-            script.write(_)
+            script.write("#!{0}\n\n{1}\n".format(self._exec, cmd))
 
         if restart:
             rname = "{}.restart.sh".format(step.name)
             restart_path = os.path.join(ws_path, rname)
 
             with open(restart_path, "w") as script:
-                script.write(self._exec)
-                _ = "\n\n{}\n".format(restart)
-                script.write(_)
+                script.write("#!{0}\n\n{1}\n".format(self._exec, restart))
         else:
             restart_path = None
 

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -42,11 +42,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 class LocalScriptAdapter(ScriptAdapter):
+    """A ScriptAdapter class for interfacing for local execution."""
+
     key = "local"
 
-    """
-    A ScriptAdapter class for interfacing for local execution.
-    """
     def __init__(self, **kwargs):
         """
         Initialize an instance of the LocalScriptAdapter.

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -41,11 +41,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 class LocalScriptAdapter(ScriptAdapter):
+    """A ScriptAdapter class for interfacing for local execution."""
+
     key = "local"
 
-    """
-    A ScriptAdapter class for interfacing for local execution.
-    """
     def __init__(self, **kwargs):
         """
         Initialize an instance of the LocalScriptAdapter.

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -36,6 +36,7 @@ import re
 from maestrowf.abstracts.interfaces import SchedulerScriptAdapter
 from maestrowf.abstracts.enums import JobStatusCode, State, SubmissionCode, \
     CancelCode
+from maestrowf.interfaces.script import SubmissionRecord
 from maestrowf.utils import start_process
 
 LOGGER = logging.getLogger(__name__)
@@ -194,10 +195,11 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
 
         if retcode == 0:
             LOGGER.info("Submission returned status OK.")
-            return SubmissionCode.OK, re.search('[0-9]+', output).group(0)
+            jid = re.search('[0-9]+', output).group(0)
+            return SubmissionRecord(SubmissionCode.OK, retcode, jid)
         else:
             LOGGER.warning("Submission returned an error.")
-            return SubmissionCode.ERROR, -1
+            return SubmissionRecord(SubmissionCode.ERROR, retcode)
 
     def check_jobs(self, joblist):
         """


### PR DESCRIPTION
After some discussion with @lucpeterson @jsemler @koning @robinson96 , it was decided that adapters should rely on `Record` classes to improve the ability of adapters to pass back extra information. Their use case is specifically referring to the `submit` method of adapters, but the notion of records is useful to all adapter calls. I've gone ahead and ported all methods to a record class.