### PR TITLE
Enhance shell batch setting to apply to scheduler scripts.

### DIFF
--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -64,12 +64,15 @@ class SchedulerScriptAdapter(ScriptAdapter):
     # Just allocate based on nodes.
     node_alloc = r"(?P<nodes>[0-9]+)n"
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """Initialize an empty ScriptAdapter object."""
         # NOTE: The _batch member should be used to store persistent batching
         # parameters. The entries in this dictionary are meant to capture the
         # the base settings for submission to a batch. This member variables
         # should never be used publicallly outside of an instance.
+
+        # Call super to set self._exec
+        super(SchedulerScriptAdapter, self).__init__(**kwargs)
         self._batch = {}
 
     def add_batch_parameter(self, name, value):

--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -65,7 +65,13 @@ class SchedulerScriptAdapter(ScriptAdapter):
     node_alloc = r"(?P<nodes>[0-9]+)n"
 
     def __init__(self, **kwargs):
-        """Initialize an empty ScriptAdapter object."""
+        """
+        Initialize an empty ScriptAdapter object.
+
+        :param kwargs: Key-value dictionary of arguments.
+
+        Currently we only support the "shell" keyword.
+        """
         # NOTE: The _batch member should be used to store persistent batching
         # parameters. The entries in this dictionary are meant to capture the
         # the base settings for submission to a batch. This member variables

--- a/maestrowf/abstracts/interfaces/scriptadapter.py
+++ b/maestrowf/abstracts/interfaces/scriptadapter.py
@@ -54,6 +54,11 @@ class ScriptAdapter(object):
     """
 
     def __init__(self, **kwargs):
+        """
+        Initialize a new instance of a ScriptAdapter.
+
+        :param kwargs: The key value arguments for the ScriptAdapter instance.
+        """
         self._exec = kwargs.pop("shell", "/bin/bash")
         LOGGER.debug("Shell set to '%s'.", self._exec)
 
@@ -142,7 +147,7 @@ class ScriptAdapter(object):
     @abstractmethod
     def key(self):
         """
-        The key to be used in workflow specification to describe the adapter.
+        Return the key name for a ScriptAdapter..
 
         This is used to register the adapter in the ScriptAdapterFactory
         and when writing the workflow specification.

--- a/maestrowf/abstracts/interfaces/scriptadapter.py
+++ b/maestrowf/abstracts/interfaces/scriptadapter.py
@@ -53,6 +53,10 @@ class ScriptAdapter(object):
     - Checking job status.
     """
 
+    def __init__(self, **kwargs):
+        self._exec = kwargs.pop("shell", "/bin/bash")
+        LOGGER.debug("Shell set to '%s'.", self._exec)
+
     @abstractmethod
     def check_jobs(self, joblist):
         """

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -81,7 +81,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
 
         :param **kwargs: A dictionary with default settings for the adapter.
         """
-        super(SpectrumFluxScriptAdapter, self).__init__()
+        super(SpectrumFluxScriptAdapter, self).__init__(**kwargs)
 
         # NOTE: These libraries are compiled at runtime when an allocation
         # is spun up.
@@ -94,7 +94,6 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         self._mpi_exe = kwargs.pop("mpi")
         self._addl_args = kwargs.pop("args", [])
 
-        self._exec = "#!/bin/bash"
         # Header is only for informational purposes.
         self._header = {
             "nodes": "#SBATCH -N {nodes}",
@@ -502,7 +501,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
 
         :param **kwargs: A dictionary with default settings for the adapter.
         """
-        super(FluxScriptAdapter, self).__init__()
+        super(FluxScriptAdapter, self).__init__(**kwargs)
 
         # NOTE: These libraries are compiled at runtime when an allocation
         # is spun up.
@@ -514,7 +513,6 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
         self._addl_args = kwargs.get("args", [])
 
-        self._exec = "#!/bin/bash"
         # Header is only for informational purposes.
         self._header = {
             "nodes": "#INFO (nodes) {nodes}",

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -55,8 +55,8 @@ class LocalScriptAdapter(ScriptAdapter):
 
         :param **kwargs: A dictionary with default settings for the adapter.
         """
-        super(LocalScriptAdapter, self).__init__()
-
+        LOGGER.debug("kwargs\n--------------------------\n%s", kwargs)
+        super(LocalScriptAdapter, self).__init__(**kwargs)
 
     def _write_script(self, ws_path, step):
         """

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -57,7 +57,6 @@ class LocalScriptAdapter(ScriptAdapter):
         """
         super(LocalScriptAdapter, self).__init__()
 
-        self._exec = kwargs.pop("shell", "/bin/bash")
 
     def _write_script(self, ws_path, step):
         """

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -63,7 +63,7 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
 
         :param **kwargs: A dictionary with default settings for the adapter.
         """
-        super(SlurmScriptAdapter, self).__init__()
+        super(SlurmScriptAdapter, self).__init__(**kwargs)
 
         # NOTE: Host doesn't seem to matter for SLURM. sbatch assumes that the
         # current host is where submission occurs.

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -238,6 +238,9 @@ def run_study(args):
     if not spec.batch:
         exec_dag.set_adapter({"type": "local"})
     else:
+        if "type" not in spec.batch:
+            spec.batch["type"] = "local"
+
         exec_dag.set_adapter(spec.batch)
 
     # Copy the spec to the output directory

--- a/samples/lulesh/lulesh_sample1_macosx.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx.yaml
@@ -16,6 +16,9 @@ env:
           url: https://github.com/LLNL/LULESH.git
           tag: 2.0.3
 
+batch:
+    shell: /bin/bash
+
 study:
     - name: make-lulesh
       description: Build the serial version of LULESH.


### PR DESCRIPTION
This extends #181 to allow for shells to be specified for all other adapters by guaranteeing that the shell parameter is popped in the base `ScriptAdapter` base class.