### PR TITLE
Extend the Specification interface to break out loading from streams.

### DIFF
--- a/maestrowf/abstracts/specification.py
+++ b/maestrowf/abstracts/specification.py
@@ -45,7 +45,18 @@ class Specification(object):
         Method for loading a study specification.
 
         :param path: Path to a study specification.
-        :returns: A specification object containing the information from path.
+        :returns: A specification object containing the information loaded
+        from path.
+        """
+        pass
+
+    @abstractclassmethod
+    def load_specification_from_str(cls, string):
+        """
+        Method for loading a study specification.
+
+        :param path: Path to a study specification.
+        :returns: A specification object containing the information in string.
         """
         pass
 

--- a/maestrowf/abstracts/specification.py
+++ b/maestrowf/abstracts/specification.py
@@ -42,7 +42,7 @@ class Specification(object):
     @abstractclassmethod
     def load_specification(cls, path):
         """
-        Method for loading a study specification.
+        Method for loading a study specification from a file.
 
         :param path: Path to a study specification.
         :returns: A specification object containing the information loaded
@@ -51,11 +51,11 @@ class Specification(object):
         pass
 
     @abstractclassmethod
-    def load_specification_from_str(cls, string):
+    def load_specification_from_stream(cls, stream):
         """
-        Method for loading a study specification.
+        Method for loading a study specification from a stream.
 
-        :param string: Raw text containing specification data.
+        :param stream: Raw text stream containing specification data.
         :returns: A specification object containing the information in string.
         """
         pass

--- a/maestrowf/abstracts/specification.py
+++ b/maestrowf/abstracts/specification.py
@@ -55,7 +55,7 @@ class Specification(object):
         """
         Method for loading a study specification.
 
-        :param path: Path to a study specification.
+        :param string: Raw text containing specification data.
         :returns: A specification object containing the information in string.
         """
         pass

--- a/maestrowf/datastructures/yamlspecification.py
+++ b/maestrowf/datastructures/yamlspecification.py
@@ -107,8 +107,9 @@ class YAMLSpecification(Specification):
         """
         Load a study specification.
 
-        :param path: Path to a study specification.
-        :returns: A specification object containing the information from path.
+        :param stream: Raw text stream to study YAML specification data.
+        :returns: A specification object containing the information from the
+        passed stream.
         """
 
         try:

--- a/maestrowf/datastructures/yamlspecification.py
+++ b/maestrowf/datastructures/yamlspecification.py
@@ -30,6 +30,7 @@
 """Module containing all things needed for a YAML Study Specification."""
 
 from copy import deepcopy
+from io import StringIO
 import logging
 import yaml
 
@@ -95,22 +96,33 @@ class YAMLSpecification(Specification):
         try:
             # Load the YAML spec from the file.
             with open(path, 'r') as data:
-                try:
-                    spec = yaml.load(data, yaml.FullLoader)
-                except AttributeError:
-                    logger.warning(
-                        "*** PyYAML is using an unsafe version with a known "
-                        "load vulnerability. Please upgrade your installation "
-                        "to a more recent version! ***")
-                    spec = yaml.load(data)
-
+                specification = cls.load_specification_from_stream(data)
         except Exception as e:
             logger.exception(e.args)
             raise
 
+        return specification
+
+    @classmethod
+    def load_specification_from_stream(cls, stream):
+        """
+        Load a study specification.
+
+        :param path: Path to a study specification.
+        :returns: A specification object containing the information from path.
+        """
+
+        try:
+            spec = yaml.load(stream, yaml.FullLoader)
+        except AttributeError:
+            logger.warning(
+                "*** PyYAML is using an unsafe version with a known "
+                "load vulnerability. Please upgrade your installation "
+                "to a more recent version! ***")
+            spec = yaml.load(stream)
+
         logger.debug("Loaded specification -- \n%s", spec["description"])
         specification = cls()
-        specification.path = path
         specification.description = spec.pop("description", {})
         specification.environment = spec.pop("env",
                                              {'variables': {},

--- a/maestrowf/datastructures/yamlspecification.py
+++ b/maestrowf/datastructures/yamlspecification.py
@@ -30,7 +30,6 @@
 """Module containing all things needed for a YAML Study Specification."""
 
 from copy import deepcopy
-from io import StringIO
 import logging
 import yaml
 


### PR DESCRIPTION
As mentioned in #197, the `load_specification` method handled loading a specification from a file. The method previously would open the filestream, load the contents and parse to a `Specification` object instance. This method has been broken down into two components now: `load_specification` to load from a file and `load specification_from_stream` to load from raw streams.

This serves two purposes: a. it fulfills the use case in #197 such that Maestro can be used now to programmatically generate specifications and get `Specification` objects from them (in the library use case) and b. it breaks down the larger functionality present to smaller functionality (design principles).

@ben-bay -- Feel free to test/offer feedback here.