### PR TITLE
Moved SLURM parameters to be placed in front of the submitted script.

### DIFF
--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -179,7 +179,7 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
                 cmd += ["--reservation", self._batch["reservation"]]
 
         # Append the script path and working directory.
-        cmd += [path, "-D", cwd]
+        cmd += ["-D", cwd, path]
         cmd = " ".join(cmd)
 
         LOGGER.debug("cwd = %s", cwd)


### PR DESCRIPTION
This corrects the ordering issue discovered in #201.