### PR TITLE
Enhances pgen to take in the environment specified in a study.

### DIFF
--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -183,6 +183,11 @@ def run_study(args):
         LOGGER.exception(msg)
         raise ArgumentError(msg)
 
+    # Addition of the $(SPECROOT) to the environment.
+    spec_root = os.path.split(args.specification)[0]
+    spec_root = Variable("SPECROOT", os.path.abspath(spec_root))
+    environment.add(spec_root)
+
     # Handle loading a custom ParameterGenerator if specified.
     if args.pgen:
         # 'pgen_args' has a default of an empty list, which should translate
@@ -190,14 +195,11 @@ def run_study(args):
         kwargs = create_dictionary(args.pargs)
         # Copy the Python file used to generate parameters.
         shutil.copy(args.pgen, output_path)
+        kwargs["OUTPUT_PATH"] = output_path
+        kwargs["SPECROOT"] = spec_root
         parameters = load_parameter_generator(args.pgen, kwargs)
     else:
         parameters = spec.get_parameters()
-
-    # Addition of the $(SPECROOT) to the environment.
-    spec_root = os.path.split(args.specification)[0]
-    spec_root = Variable("SPECROOT", os.path.abspath(spec_root))
-    environment.add(spec_root)
 
     # Setup the study.
     study = Study(spec.name, spec.description, studyenv=environment,

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -96,9 +96,9 @@ def load_parameter_generator(path, env, kwargs):
 
     :param path: Path to a Python file containing the function \
     'get_custom_generator'.
+    :param env: A StudyEnvironment object containing custom information.
     :param kwargs: Dictionary containing keyword arguments for the function \
     'get_custom_generator'.
-    :param env: A StudyEnvironment object containing custom information.
     :returns: A populated ParameterGenerator instance.
     """
     path = os.path.abspath(path)

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -200,7 +200,6 @@ def run_study(args):
         # Add keywords and environment from the spec to pgen args.
         kwargs["OUTPUT_PATH"] = output_path
         kwargs["SPECROOT"] = spec_root
-        kwargs["study_env"] = environment
 
         # Load the parameter generator.
         parameters = load_parameter_generator(args.pgen, environment, kwargs)

--- a/samples/lulesh/lulesh_sample1_macosx.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx.yaml
@@ -4,6 +4,12 @@ description:
 
 env:
     variables:
+        # DEFAULTS FOR MONTECARLO PGEN EXAMPLE
+        SMIN:        10
+        SMAX:        30
+        TRIALS:      50
+        ITER:        100
+
         OUTPUT_PATH: ./sample_output/lulesh
 
     labels:

--- a/samples/lulesh/lulesh_sample1_unix.yaml
+++ b/samples/lulesh/lulesh_sample1_unix.yaml
@@ -4,6 +4,12 @@ description:
 
 env:
     variables:
+        # DEFAULTS FOR MONTECARLO PGEN EXAMPLE
+        SMIN:        10
+        SMAX:        30
+        TRIALS:      50
+        ITER:        100
+
         OUTPUT_PATH: ./sample_output/lulesh
 
     labels:

--- a/samples/parameterization/custom_generator.py
+++ b/samples/parameterization/custom_generator.py
@@ -3,7 +3,7 @@
 from maestrowf.datastructures.core import ParameterGenerator
 
 
-def get_custom_generator():
+def get_custom_generator(env, **kwargs):
     """
     Create a custom populated ParameterGenerator.
 

--- a/samples/parameterization/lulesh_custom_gen.py
+++ b/samples/parameterization/lulesh_custom_gen.py
@@ -3,7 +3,7 @@
 from maestrowf.datastructures.core import ParameterGenerator
 
 
-def get_custom_generator():
+def get_custom_generator(env, **kwargs):
     """
     Create a custom populated ParameterGenerator.
 

--- a/samples/parameterization/lulesh_montecarlo_args.py
+++ b/samples/parameterization/lulesh_montecarlo_args.py
@@ -5,7 +5,7 @@ from random import randint
 from maestrowf.datastructures.core import ParameterGenerator
 
 
-def get_custom_generator(**kwargs):
+def get_custom_generator(env, **kwargs):
     """
     Create a custom populated ParameterGenerator.
 
@@ -17,10 +17,10 @@ def get_custom_generator(**kwargs):
     :returns: A ParameterGenerator populated with parameters.
     """
     p_gen = ParameterGenerator()
-    trials = int(kwargs.get("trials"))
-    size_min = int(kwargs.get("smin"))
-    size_max = int(kwargs.get("smax"))
-    iterations = int(kwargs.get("iter"))
+    trials = int(kwargs.get("trials", env.find("TRIALS").value))
+    size_min = int(kwargs.get("smin", env.find("SMIN").value))
+    size_max = int(kwargs.get("smax", env.find("SMAX").value))
+    iterations = int(kwargs.get("iter", env.find("ITER").value))
     params = {
         "TRIAL": {
             "values": [i for i in range(1, trials)],


### PR DESCRIPTION
Previously, custom parameter generators were unaware of the environment defined in a study specification. This PR tweaks that so that the `StudyEnvironment` data structure is passed to the pgen function so that variables can be consistently defined between the specification and pgen.

This change enables studies which might rely on constructing a list of items in a directory to generate parameters, study specified defaults for parameters, and implementation/method switching (just to name a few).