### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
   extras_require={},
   long_description_content_type='text/markdown',
   download_url='https://pypi.org/project/maestrowf/',
-  python_requires='>=2.7.*, ~=3.5',
+  python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Operating System :: Unix',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
   extras_require={},
   long_description_content_type='text/markdown',
   download_url='https://pypi.org/project/maestrowf/',
-  python_requires='~=3.5',
+  python_requires='~=2.7, ~=3.5',
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Operating System :: Unix',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
   'workflows.',
   version=__version__,
   author='Francesco Di Natale',
+  maintainer='Francesco Di Natale',
   author_email='dinatale3@llnl.gov',
   url='https://github.com/llnl/maestrowf',
   license='MIT License',
@@ -24,7 +25,9 @@ setup(
     "tabulate",
   ],
   extras_require={},
-  long_description_content_type="text/markdown",
+  long_description_content_type='text/markdown',
+  download_url='https://pypi.org/project/maestrowf/',
+  python_requires='~=3.5',
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Operating System :: Unix',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
   extras_require={},
   long_description_content_type='text/markdown',
   download_url='https://pypi.org/project/maestrowf/',
-  python_requires='>=2.7, ~=3.5',
+  python_requires='>=2.7.*, ~=3.5',
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Operating System :: Unix',

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,42 @@
 from maestrowf import __version__
 from setuptools import setup, find_packages
 
-setup(name='maestrowf',
-      description='A tool and library for specifying and conducting general '
-      'workflows.',
-      version=__version__,
-      author='Francesco Di Natale',
-      author_email='dinatale3@llnl.gov',
-      url='https://github.com/llnl/maestrowf',
-      license='MIT License',
-      packages=find_packages(),
-      entry_points={
-        'console_scripts': [
-            'maestro = maestrowf.maestro:main',
-            'conductor = maestrowf.conductor:main',
-        ]
-      },
-      install_requires=[
-        'PyYAML>=4.2b1',
-        'six',
-        "filelock",
-        "tabulate",
-        "enum34 ; python_version<'3.4'"
-        ],
-      extras_require={},
-      long_description_content_type="text/markdown",
-      classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Operating System :: Unix',
-        'Operating System :: MacOS :: MacOS X',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'Topic :: Scientific/Engineering',
-        'Topic :: System :: Distributed Computing',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        ],
-      )
+setup(
+  name='maestrowf',
+  description='A tool and library for specifying and conducting general '
+  'workflows.',
+  version=__version__,
+  author='Francesco Di Natale',
+  author_email='dinatale3@llnl.gov',
+  url='https://github.com/llnl/maestrowf',
+  license='MIT License',
+  packages=find_packages(),
+  entry_points={
+    'console_scripts': [
+        'maestro = maestrowf.maestro:main',
+        'conductor = maestrowf.conductor:main',
+    ]
+  },
+  install_requires=[
+    'PyYAML>=4.2b1',
+    'six',
+    "filelock",
+    "tabulate",
+  ],
+  extras_require={},
+  long_description_content_type="text/markdown",
+  classifiers=[
+    'Development Status :: 5 - Production/Stable',
+    'Operating System :: Unix',
+    'Operating System :: MacOS :: MacOS X',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Education',
+    'Intended Audience :: Science/Research',
+    'Topic :: Scientific/Engineering',
+    'Topic :: System :: Distributed Computing',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+  ],
+)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     'six',
     "filelock",
     "tabulate",
+    "enum34 ; python_version<'3.4'"
   ],
   extras_require={},
   long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
   extras_require={},
   long_description_content_type='text/markdown',
   download_url='https://pypi.org/project/maestrowf/',
-  python_requires='~=2.7, ~=3.5',
+  python_requires='>=2.7, ~=3.5',
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Operating System :: Unix',

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ skip_missing_interpreters=True
 [travis]
 python =
 	2.7: py27
-	3.4: py34
 	3.5: py35
 	3.6: py36
 


### PR DESCRIPTION
While working on another branch, it turns out that PyYAML has officially stopped support for Python 3.4. Maestro is directly reliant on PyYAML, so we'll be dropping support as well.