### PR TITLE
Applies workspace substitution to the restart command.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -48,6 +48,7 @@ class _StepRecord(object):
         """
         self.workspace = Variable("WORKSPACE", workspace)
         step.run["cmd"] = self.workspace.substitute(step.run["cmd"])
+        step.run["cmd"] = self.workspace.substitute(step.run["restart"])
 
         self.jobid = kwargs.get("jobid", [])
         self.script = kwargs.get("script", "")

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -48,7 +48,7 @@ class _StepRecord(object):
         """
         self.workspace = Variable("WORKSPACE", workspace)
         step.run["cmd"] = self.workspace.substitute(step.run["cmd"])
-        step.run["cmd"] = self.workspace.substitute(step.run["restart"])
+        step.run["restart"] = self.workspace.substitute(step.run["restart"])
 
         self.jobid = kwargs.get("jobid", [])
         self.script = kwargs.get("script", "")

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -500,7 +500,8 @@ class Study(DAG):
             # Search for workspace matches. These affect the expansion of a
             # node because they may use parameters. These are likely to cause
             # a node to fall into the 'Parameter Dependent' case.
-            used_spaces = re.findall(WSREGEX, node.run["cmd"])
+            used_spaces = re.findall(
+                WSREGEX, "{} {}".format(node.run["cmd"], node.run["restart"]))
             for ws in used_spaces:
                 if ws not in self.used_params:
                     msg = "Workspace for '{}' is being used before it would" \

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -571,6 +571,7 @@ class Study(DAG):
                 # here, it's reflected in the ExecutionGraph.
                 node = copy.deepcopy(node)
                 node.run["cmd"] = cmd
+                node.run["restart"] = r_cmd
                 logger.debug("New cmd = %s", cmd)
                 logger.debug("New restart = %s", r_cmd)
 


### PR DESCRIPTION
This PR fixes the bug found in #217 -- Workspace substitutions were overlooked for the `restart` part of the `cmd` entries in steps.