### PR TITLE
Sets log and err out for SLURM to parameterized step name

### DIFF
--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -80,11 +80,9 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
             "bank": "#SBATCH -A {bank}",
             "walltime": "#SBATCH -t {walltime}",
             "job-name":
-            """
-                #SBATCH -J "{job-name}"
-                #SBATCH -o "{job-name}.out"
-                #SBATCH -e "{job-name}.err"
-            """,
+                "#SBATCH -J \"{job-name}\"\n"
+                "#SBATCH -o \"{job-name}.out\"\n"
+                "#SBATCH -e \"{job-name}.err\"",
             "comment": "#SBATCH --comment \"{comment}\""
         }
 

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -79,7 +79,12 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
             "queue": "#SBATCH -p {queue}",
             "bank": "#SBATCH -A {bank}",
             "walltime": "#SBATCH -t {walltime}",
-            "job-name": "#SBATCH -J {job-name}",
+            "job-name":
+            """
+                #SBATCH -J "{job-name}"
+                #SBATCH -o "{job-name}.out"
+                #SBATCH -e "{job-name}.err"
+            """,
             "comment": "#SBATCH --comment \"{comment}\""
         }
 


### PR DESCRIPTION
Fixes #213 

While the SLURM adapter did set the job name when submitting to the scheduler, it had initially been assumed that the logs would be output in the same format as the name. That assumption was proven false, so now we explicitly set the name of both the error and output logs.