### PR TITLE
Improve the performance of expansion

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -1,11 +1,11 @@
 """Module for the execution of DAG workflows."""
 from collections import deque, OrderedDict
 from datetime import datetime
+import dill
 from filelock import FileLock, Timeout
 import getpass
 import logging
 import os
-import pickle
 import shutil
 import tempfile
 
@@ -447,7 +447,7 @@ class ExecutionGraph(DAG):
         :param path: Path to a ExecutionGraph pickle file.
         """
         with open(path, 'rb') as pkl:
-            dag = pickle.load(pkl)
+            dag = dill.load(pkl)
 
         if not isinstance(dag, cls):
             msg = "Object loaded from {path} is of type {type}. Expected an" \
@@ -472,7 +472,7 @@ class ExecutionGraph(DAG):
             raise Exception(msg)
 
         with open(path, 'wb') as pkl:
-            pickle.dump(self, pkl)
+            dill.dump(self, pkl)
 
     @property
     def name(self):

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -831,6 +831,10 @@ class Study(DAG):
         dag.add_description(**self.description)
         dag.log_description()
 
+        # Because we're working within a Study class whose steps have already
+        # been verified to not contain a cycle, we can override the check for
+        # the execution graph. Because the execution graph is constructed from
+        # the study steps, it won't contain a cycle.
         def _pass_detect_cycle(self):
             pass
 

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -34,6 +34,7 @@ import logging
 import os
 import pickle
 import re
+from types import MethodType
 import yaml
 
 from maestrowf.abstracts import SimObject
@@ -119,7 +120,6 @@ class StudyStep(SimObject):
         : returns: True if other is not equal to self, False otherwise.
         """
         return not self.__eq__(other)
-
 
 class Study(DAG):
     """
@@ -830,5 +830,10 @@ class Study(DAG):
             use_tmp=self._use_tmp)
         dag.add_description(**self.description)
         dag.log_description()
+
+        def _pass_detect_cycle(self):
+            pass
+
+        dag.detect_cycle = MethodType(_pass_detect_cycle, dag)
 
         return self._out_path, self._stage(dag)

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -121,6 +121,7 @@ class StudyStep(SimObject):
         """
         return not self.__eq__(other)
 
+
 class Study(DAG):
     """
     Collection of high level objects to perform study construction.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     'six',
     "filelock",
     "tabulate",
-    "enum34 ; python_version<'3.4'"
+    "enum34 ; python_version<'3.4'",
+    "dill",
   ],
   extras_require={},
   long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR is meant to improve the number of parameters that DAG expansion can handle. Some initial testing showed that cycle detection really slowed things down. Since the `ExecutionGraph` is technically cookie cut from the `Study` class (derived from a `DAG`), if the initial set of abstract steps doesn't contain a cycle, the expansion will retain that property.

There's something that I ran into as the initial solution I'm proposing is to monkey patch the `ExecutionGraph` to pass on the `detect_cycle` call.  The monkey patching works perfectly for Python3 ; however, the Python2.7 pickle library doesn't seem to be able to handle the pickling of instance methods. I hate to introduce a new dependency, but online folks seem to have settled on `dill` as a more flexible pickler that is capable of pickling a wider variety of things.