### PR TITLE
Added checks for invalid keys.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include maestrowf/datastructures/schemas.json

--- a/maestrowf/datastructures/schemas.json
+++ b/maestrowf/datastructures/schemas.json
@@ -1,0 +1,116 @@
+{
+  "DESCRIPTION": {
+    "type": "object",
+    "properties": {
+      "name": {"type": "string", "minLength": 1},
+      "description": {"type": "string", "minLength": 1}
+    },
+    "required": [
+      "name",
+      "description"
+    ]
+  },
+  "PARAM": {
+    "type": "object",
+    "properties": {
+      "values": {
+        "type": "array"
+      },
+      "label": {"type": "string", "minLength": 1}
+    },
+    "additionalProperties": false,
+    "required": [
+      "values",
+      "label"
+    ]
+  },
+  "STUDY_STEP": {
+    "type": "object",
+    "properties": {
+      "name": {"type": "string", "minLength": 1},
+      "description": {"type": "string", "minLength": 1},
+      "run": {
+        "type": "object",
+        "properties": {
+          "cmd": {"type": "string", "minLength": 1},
+          "depends": {"type": "array", "uniqueItems": true},
+          "pre": {"type": "string", "minLength": 1},
+          "post": {"type": "string", "minLength": 1},
+          "restart": {"type": "string", "minLength": 1},
+          "nodes": {"type": "integer"},
+          "procs": {"type": "integer"},
+          "gpus": {"type": "integer"},
+          "cores per task": {"type": "integer"},
+          "walltime": {"type": "string", "minLength": 1},
+          "reservation": {"type": "string", "minLength": 1}
+        },
+        "additionalProperties": false,
+        "required": [
+          "cmd"
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "name",
+      "description",
+      "run"
+    ]
+  },
+  "ENV": {
+    "type": "object",
+    "properties": {
+      "variables": {"type": "object"},
+      "labels": {"type": "object"},
+      "sources": {"type": "object"},
+      "dependencies": {
+        "type": "object",
+        "properties": {
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string", "minLength": 1},
+                "path": {"type": "string", "minLength": 1}
+              },
+              "required": [
+                "name",
+                "path"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "git": {
+            "type": "array",
+            "items": {
+              "properties": {
+                "name": {"type": "string", "minLength": 1},
+                "path": {"type": "string", "minLength": 1},
+                "url": {"type": "string", "minLength": 1},
+                "tag": {"type": "string", "minLength": 1}
+              },
+              "required": [
+                "name",
+                "path",
+                "url"
+              ]
+            }
+          },
+          "spack": {
+            "type": "object",
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "package_name": {"type": "string", "minLength": 1}
+            },
+            "required": [
+              "type",
+              "package_name"
+            ]
+          }
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -29,6 +29,7 @@
 
 """A script for launching a YAML study specification."""
 from argparse import ArgumentParser, ArgumentError, RawTextHelpFormatter
+import jsonschema
 import logging
 import os
 import shutil
@@ -124,7 +125,11 @@ def load_parameter_generator(path, env, kwargs):
 def run_study(args):
     """Run a Maestro study."""
     # Load the Specification
-    spec = YAMLSpecification.load_specification(args.specification)
+    try:
+        spec = YAMLSpecification.load_specification(args.specification)
+    except jsonschema.ValidationError as e:
+        LOGGER.error(e.message)
+        sys.exit(1)
     environment = spec.get_study_environment()
     steps = spec.get_study_steps()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ filelock
 tabulate
 enum34; python_version<'3.4'
 dill
+jsonschema>=3.2.0
 -e .
 
 fabric

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     "tabulate",
     "enum34 ; python_version<'3.4'",
     "dill",
+    "jsonschema>=3.2.0",
   ],
   extras_require={},
   long_description_content_type='text/markdown',
@@ -44,4 +45,8 @@ setup(
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
   ],
+  package_data={
+        'maestrowf': ['maestrowf/datastructures/schemas.json'],
+  },
+  include_package_data=True,
 )


### PR DESCRIPTION
This is my first attempt at adding valid key checking to Maestro. Why? Because indentation slip ups and typos can screw up a yaml spec. Worse, this type of error can be difficult to trace.

P.S. I'm sure I missed some keys that Maestro supports in `step.cmd`, so make sure to remind me of those.

P.P.S. Your `logger` appears to be broken. You'll only see this working for now if you replace my `logger.warning` with a `print`.

P.P.P.S. Speaking of logging, have you considered using color? Merlin is using the open source library [coloredlogs](https://pypi.org/project/coloredlogs/).