### PR TITLE
Pre-Commit Checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: check-toml
+    -   id: flake8

--- a/Pipfile
+++ b/Pipfile
@@ -4,23 +4,28 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-"enum34" = "*"
-filelock = "*"
+PyYAML = ">=4.2b1"
 six = "*"
+filelock = "*"
 tabulate = "*"
-Fabric = "*"
-PyYAML = ">= 4.2b1"
+dill = "*"
 maestrowf = {path = "."}
 
 [dev-packages]
-"flake8" = "*"
+flake8 = "*"
 pydocstyle = "*"
 pylint = "*"
 tox = "*"
 coverage = "*"
-sphinx_rtd_theme = "*"
-Sphinx = "*"
 pytest = "*"
+fabric = "*"
+Sphinx = "*"
+pytest-cov = "*"
+pre-commit = "*"
+sphinx-rtd-theme = "*"
+
+[pipenv]
+allow_prereleases = true
 
 [requires]
 python_version = "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,19 @@
-fabric
-coverage
-filelock
 PyYAML>=4.2b1
 six
+filelock
+tabulate
+enum34; python_version<'3.4'
+dill
+-e .
+
+fabric
+coverage
 sphinx_rtd_theme
 sphinx
 flake8
 pydocstyle
 pylint
 tox
-tabulate
 pytest
-enum34; python_version<'3.4'
-dill
+pytest-cov
+pre-commit


### PR DESCRIPTION
Added pre-commit to enable flake8 checks before a commit is accepted. This ensures that checked in code passes flake8 before it is ever allowed the be commited. 

Pre-Commit can also be used to sort imports and reformat code using isort and black respectively.

Also reordered requirements.txt to more easily determine which are for development.