### PR TITLE
No "variables" bugfix

### DIFF
--- a/maestrowf/datastructures/schemas.json
+++ b/maestrowf/datastructures/schemas.json
@@ -62,7 +62,7 @@
     "properties": {
       "variables": {"type": "object"},
       "labels": {"type": "object"},
-      "sources": {"type": "object"},
+      "sources": {"type": "array"},
       "dependencies": {
         "type": "object",
         "properties": {

--- a/maestrowf/datastructures/yamlspecification.py
+++ b/maestrowf/datastructures/yamlspecification.py
@@ -197,6 +197,8 @@ class YAMLSpecification(Specification):
         :returns: A set of keys encountered in the variables section.
         """
         keys_seen = set()
+        if "variables" not in self.environment:
+            return keys_seen
         for key, value in self.environment["variables"].items():
             logger.debug("Verifying %s...", key)
             if not key:


### PR DESCRIPTION
This wasn't directly related to `jsonschema`, it was just a `KeyError` in our spec verification code. But this did uncover a teeny schema bug.