### PR TITLE
Addition of a simple dry-run capability.

### DIFF
--- a/maestrowf/abstracts/enums/__init__.py
+++ b/maestrowf/abstracts/enums/__init__.py
@@ -65,6 +65,7 @@ class State(Enum):
     TIMEDOUT = 10
     UNKNOWN = 11
     CANCELLED = 12
+    DRYRUN = 13
 
 
 class StudyStatus(Enum):

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -302,7 +302,7 @@ class ExecutionGraph(DAG, PickleInterface):
     """
 
     def __init__(self, submission_attempts=1, submission_throttle=0,
-                 use_tmp=False):
+                 use_tmp=False, dry_run=False):
         """
         Initialize a new instance of an ExecutionGraph.
 
@@ -336,6 +336,7 @@ class ExecutionGraph(DAG, PickleInterface):
         # throttling, etc. should be listed here.
         self._submission_attempts = submission_attempts
         self._submission_throttle = submission_throttle
+        self.dry_run = dry_run
 
         # A map that tracks the dependencies of a step.
         # NOTE: I don't know how performant the Python dict structure is, but
@@ -536,6 +537,20 @@ class ExecutionGraph(DAG, PickleInterface):
         # 1. If the JobStatus is not OK.
         # 2. num_restarts is less than self._submission_attempts
         self._check_tmp_dir()
+
+        # Only set up the workspace the initial iteration.
+        if not restart:
+            LOGGER.debug("Setting up workspace for '%s' at %s",
+                         record.name, str(datetime.now()))
+            # Generate the script for execution on the fly.
+            record.setup_workspace()    # Generate the workspace.
+            record.generate_script(adapter, self._tmp_dir)
+
+        if self.dry_run:
+            record.mark_end(State.FINISHED)
+            self.completed_steps.add(record.name)
+            return
+
         while retcode != SubmissionCode.OK and \
                 num_restarts < self._submission_attempts:
             LOGGER.info("Attempting submission of '%s' (attempt %d of %d)...",
@@ -546,9 +561,6 @@ class ExecutionGraph(DAG, PickleInterface):
             if not restart:
                 LOGGER.debug("Calling 'execute' on '%s' at %s",
                              record.name, str(datetime.now()))
-                # Generate the script for execution on the fly.
-                record.setup_workspace()    # Generate the workspace.
-                record.generate_script(adapter, self._tmp_dir)
                 retcode = record.execute(adapter)
             # Otherwise, it's a restart.
             else:
@@ -659,7 +671,14 @@ class ExecutionGraph(DAG, PickleInterface):
         adapter = ScriptAdapterFactory.get_adapter(self._adapter["type"])
         adapter = adapter(**self._adapter)
 
-        retcode, job_status = self.check_study_status()
+        if not self.dry_run:
+            LOGGER.debug("Checking status check...")
+            retcode, job_status = self.check_study_status()
+        else:
+            LOGGER.debug("DRYRUN: Skipping status check...")
+            retcode = JobStatusCode.OK
+            job_status = {}
+
         LOGGER.debug("Checked status (retcode %s)-- %s", retcode, job_status)
 
         # For now, if we can't check the status something is wrong.

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -547,7 +547,7 @@ class ExecutionGraph(DAG, PickleInterface):
             record.generate_script(adapter, self._tmp_dir)
 
         if self.dry_run:
-            record.mark_end(State.FINISHED)
+            record.mark_end(State.DRYRUN)
             self.completed_steps.add(record.name)
             return
 

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -233,10 +233,11 @@ def run_study(args):
 
     # Set up the study workspace and configure it for execution.
     study.setup_workspace()
-    study.setup_environment()
     study.configure_study(
         throttle=args.throttle, submission_attempts=args.attempts,
-        restart_limit=args.rlimit, use_tmp=args.usetmp, hash_ws=args.hashws)
+        restart_limit=args.rlimit, use_tmp=args.usetmp, hash_ws=args.hashws,
+        dry_run=args.dryrun)
+    study.setup_environment()
 
     batch = {"type": "local"}
     if spec.batch:
@@ -245,9 +246,7 @@ def run_study(args):
             batch["type"] = "local"
     # Copy the spec to the output directory
     shutil.copy(args.specification, study.output_path)
-    # Check for a dry run
-    if args.dryrun:
-        raise NotImplementedError("The 'dryrun' mode is in development.")
+
     # Use the Conductor's classmethod to store the study.
     Conductor.store_study(study)
     Conductor.store_batch(study.output_path, batch)

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -259,7 +259,7 @@ def run_study(args):
     Conductor.store_batch(study.output_path, batch)
 
     # If we are automatically launching, just set the input as yes.
-    if args.autoyes:
+    if args.autoyes or args.dry:
         uinput = "y"
     elif args.autono:
         uinput = "n"

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -239,6 +239,13 @@ def run_study(args):
         dry_run=args.dryrun)
     study.setup_environment()
 
+    if args.dryrun:
+        # If performing a dry run, drive sleep time down to generate scripts.
+        sleeptime = 1
+    else:
+        # else, use args to decide sleeptime
+        sleeptime = args.sleeptime
+
     batch = {"type": "local"}
     if spec.batch:
         batch = spec.batch
@@ -264,7 +271,7 @@ def run_study(args):
             # Launch in the foreground.
             LOGGER.info("Running Maestro Conductor in the foreground.")
             conductor = Conductor(study)
-            conductor.initialize(batch, args.sleeptime)
+            conductor.initialize(batch, sleeptime)
             completion_status = conductor.monitor_study()
             conductor.cleanup()
             return completion_status.value
@@ -275,7 +282,7 @@ def run_study(args):
                 *["{}.txt".format(study.name)])
 
             cmd = ["nohup", "conductor",
-                   "-t", str(args.sleeptime),
+                   "-t", str(sleeptime),
                    "-d", str(args.debug_lvl),
                    study.output_path,
                    ">", log_path, "2>&1"]

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -236,10 +236,10 @@ def run_study(args):
     study.configure_study(
         throttle=args.throttle, submission_attempts=args.attempts,
         restart_limit=args.rlimit, use_tmp=args.usetmp, hash_ws=args.hashws,
-        dry_run=args.dryrun)
+        dry_run=args.dry)
     study.setup_environment()
 
-    if args.dryrun:
+    if args.dry:
         # If performing a dry run, drive sleep time down to generate scripts.
         sleeptime = 1
     else:
@@ -331,7 +331,7 @@ def setup_argparser():
     run.add_argument("-s", "--sleeptime", type=int, default=60,
                      help="Amount of time (in seconds) for the manager to "
                      "wait between job status checks. [Default: %(default)d]")
-    run.add_argument("-d", "--dryrun", action="store_true", default=False,
+    run.add_argument("--dry", action="store_true", default=False,
                      help="Generate the directory structure and scripts for a "
                      "study but do not launch it. [Default: %(default)s]")
     run.add_argument("-p", "--pgen", type=str,


### PR DESCRIPTION
This PR adds a simple dry run that forces Maestro to skip scheduler status checking, execution, and generates all workspaces and scripts so that users can see what's generated before kicking off studies. Closes #228.