### PR TITLE
Tweaks and fixes to the SLURM header.

### DIFF
--- a/maestrowf/datastructures/schemas.json
+++ b/maestrowf/datastructures/schemas.json
@@ -42,7 +42,8 @@
           "gpus": {"type": "integer"},
           "cores per task": {"type": "integer"},
           "walltime": {"type": "string", "minLength": 1},
-          "reservation": {"type": "string", "minLength": 1}
+          "reservation": {"type": "string", "minLength": 1},
+          "exclusive": {"type": "boolean"}
         },
         "additionalProperties": false,
         "required": [

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -32,7 +32,11 @@ import getpass
 import logging
 import os
 import re
-from collections import ChainMap
+# In order to support Python2.7, we need to catch the import error.
+try:
+    from collections import ChainMap
+except ImportError:
+    from chainmap import ChainMap
 
 from maestrowf.abstracts.interfaces import SchedulerScriptAdapter
 from maestrowf.abstracts.enums import JobStatusCode, State, SubmissionCode, \

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -79,6 +79,12 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
         self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
         self.add_batch_parameter("reservation", kwargs.pop("reservation", ""))
 
+        # Check for procs separately, as we don't want it in the header if it's
+        # not present.
+        procs = kwargs.get("procs", None)
+        if procs:
+            self.add_batch_parameter("procs", procs)
+
         self._header = {
             "nodes": "#SBATCH --nodes={nodes}",
             "queue": "#SBATCH --partition={queue}",
@@ -121,6 +127,11 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
 
             if resources[key]:
                 modified_header.append(value.format(**resources))
+
+        if "procs" in self._batch:
+            modified_header.append(
+                "#SBATCH --ntasks={}".format(resources["procs"])
+            )
 
         exclusive = resources.get("exclusive", False)
         if exclusive:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ enum34; python_version<'3.4'
 dill
 jsonschema>=3.2.0
 coloredlogs
+chainmap; python_version<'3'
 -e .
 
 fabric

--- a/samples/lulesh/lulesh_sample1_unix_slurm.yaml
+++ b/samples/lulesh/lulesh_sample1_unix_slurm.yaml
@@ -21,6 +21,7 @@ batch:
     bank        : baasic
     queue       : pbatch
     gres        : ignore
+    reservation : test_reservation
 
 study:
     - name: make-lulesh
@@ -43,6 +44,7 @@ study:
           depends: [make-lulesh]
           nodes: 2
           procs: 27
+          exclusive   : True
           walltime: "00:10:00"
 
 global.parameters:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     "dill",
     "jsonschema>=3.2.0",
     "coloredlogs",
+    "chainmap ; python_version<'3'",
   ],
   extras_require={},
   long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds the ability to specify GPUs, fixes reservation pairing with accounts, and now uses a ChainMap to handle the internal key conflicts between the batch and step settings. Also introduces the exclusive key. Changed to full parameter names for clarity.

Closes #239. Might be useful for #234.