### PR TITLE
modified executiongraph to round datetimes to nearest second

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -14,7 +14,7 @@ from maestrowf.abstracts.enums import JobStatusCode, State, SubmissionCode, \
 from maestrowf.datastructures.dag import DAG
 from maestrowf.datastructures.environment import Variable
 from maestrowf.interfaces import ScriptAdapterFactory
-from maestrowf.utils import create_parentdir, get_duration
+from maestrowf.utils import create_parentdir, get_duration, round_datetime_seconds
 
 LOGGER = logging.getLogger(__name__)
 SOURCE = "_source"
@@ -140,7 +140,7 @@ class _StepRecord:
             self.status)
         self.status = State.PENDING
         if not self._submit_time:
-            self._submit_time = datetime.now()
+            self._submit_time = round_datetime_seconds(datetime.now())
         else:
             LOGGER.warning(
                 "Cannot set the submission time of '%s' because it has "
@@ -155,7 +155,7 @@ class _StepRecord:
             self.status)
         self.status = State.RUNNING
         if not self._start_time:
-            self._start_time = datetime.now()
+            self._start_time = round_datetime_seconds(datetime.now())
 
     def mark_end(self, state):
         """
@@ -170,7 +170,7 @@ class _StepRecord:
             self.status)
         self.status = state
         if not self._end_time:
-            self._end_time = datetime.now()
+            self._end_time = round_datetime_seconds(datetime.now())
 
     def mark_restart(self):
         """Mark the end time of the record."""

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -38,13 +38,14 @@ from subprocess import PIPE, Popen
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import HTTPError, URLError
 import time
+import datetime
 
 LOGGER = logging.getLogger(__name__)
 
 
 def get_duration(time_delta):
     """
-    Covert durations to HH:MM:SS format.
+    Convert durations to HH:MM:SS format.
 
     :params time_delta: A time difference in datatime format.
     :returns: A formatted string in HH:MM:SS
@@ -57,6 +58,20 @@ def get_duration(time_delta):
 
     return "{:d}d:{:02d}h:{:02d}m:{:02d}s" \
            .format(days, hours, minutes, seconds)
+
+def round_datetime_seconds(input_datetime):
+    """
+    Round datetime to the nearest whole second.
+
+    :params input_datetime: A datetime in datatime format.
+    :returns: ``input_datetime`` rounded to the nearest whole second
+    """
+    new_datetime = input_datetime
+
+    if new_datetime.microsecond >= 500000:
+        new_datetime = new_datetime + datetime.timedelta(seconds=1)
+
+    return new_datetime.replace(microsecond=0)
 
 
 def generate_filename(path, append_time=True):


### PR DESCRIPTION
The main reason to do this was to improve the formatting of `maestro status`. 

An alternate solution would be to modify the getters, or status read and write, but this solution is a little cleaner and faster, and it has the same result. 

If there is a use case that needs more precise datetime stamps, other solutions could be considered. 

And, to give credit where credit is due: 

https://stackoverflow.com/questions/47792242/rounding-time-off-to-the-nearest-second-python. 