### PR TITLE
Adds a check for UNKNOWN state.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -14,7 +14,8 @@ from maestrowf.abstracts.enums import JobStatusCode, State, SubmissionCode, \
 from maestrowf.datastructures.dag import DAG
 from maestrowf.datastructures.environment import Variable
 from maestrowf.interfaces import ScriptAdapterFactory
-from maestrowf.utils import create_parentdir, get_duration, round_datetime_seconds
+from maestrowf.utils import create_parentdir, get_duration, \
+    round_datetime_seconds
 
 LOGGER = logging.getLogger(__name__)
 SOURCE = "_source"

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -766,29 +766,13 @@ class ExecutionGraph(DAG, PickleInterface):
                     cleanup_steps.update(self.bfs_subtree(name)[0])
 
                 elif status == State.UNKNOWN:
-                    LOGGER.info("Statue found to be UNKNOWN...")
-                    if record.status == State.FINISHING:
-                        # If we don't know what the state is, but we know
-                        # it was previously finishing chances are it finished
-                        # successfully.
-                        record.mark_end(State.FINISHED)
-                        LOGGER.info(
-                            "Step '%s' marked as finished. Found to be in "
-                            "UNKNOWN state when previously in FINISHING.",
-                            " Adding to completed set.", name)
-                        self.completed_steps.add(name)
-                    else:
-                        # We don't know the current state, so we mark it as
-                        # failed. It appears that if something happens in the
-                        # completion hooks, a scheduler can abort.
-                        record.mark_end(State.FAILED)
-                        LOGGER.info(
-                            "Step '%s' found in UNKNOWN state. Step was found "
-                            "in '%s' state previously, making as UNKNOWN. "
-                            "Adding to completed step in the event that step "
-                            "succeeded. Adding to failed set.",
-                            name, record.status)
-                        cleanup_steps.update(self.bfs_subtree(name)[0])
+                    record.mark_end(State.UNKNOWN)
+                    LOGGER.info(
+                        "Step '%s' found in UNKNOWN state. Step was found "
+                        "in '%s' state previously, marking as UNKNOWN. "
+                        "Adding to failed steps.",
+                        name, record.status)
+                    cleanup_steps.update(self.bfs_subtree(name)[0])
                     self.in_progress.remove(name)
 
                 elif status == State.CANCELLED:

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -766,7 +766,8 @@ class ExecutionGraph(DAG, PickleInterface):
                     cleanup_steps.update(self.bfs_subtree(name)[0])
 
                 elif status == State.UNKNOWN:
-                    if record.state == State.FINISHING:
+                    LOGGER.info("Statue found to be UNKNOWN...")
+                    if record.status == State.FINISHING:
                         # If we don't know what the state is, but we know
                         # it was previously finishing chances are it finished
                         # successfully.
@@ -785,7 +786,7 @@ class ExecutionGraph(DAG, PickleInterface):
                             "in '%s' state previously, making as UNKNOWN. "
                             "Adding to completed step in the event that step "
                             "succeeded. Adding to completed set.",
-                            name, record.state)
+                            name, record.status)
                     self.completed_steps.add(name)
                     self.in_progress.remove(name)
 

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -59,9 +59,13 @@ def get_duration(time_delta):
     return "{:d}d:{:02d}h:{:02d}m:{:02d}s" \
            .format(days, hours, minutes, seconds)
 
+
 def round_datetime_seconds(input_datetime):
     """
     Round datetime to the nearest whole second.
+
+    Solution referenced from: https://stackoverflow.com/questions/47792242/
+    rounding-time-off-to-the-nearest-second-python.
 
     :params input_datetime: A datetime in datatime format.
     :returns: ``input_datetime`` rounded to the nearest whole second


### PR DESCRIPTION
Fixes #264 -- After some testing it appears SLURM loses track of the jobs when in completing state because the system runs out of memory and aborts them. I think it might be reasonable to assume that if you can't find the status, then it likely was killed for some abnormal reason as I do have jobs that seem to successfully finished.

Previously: If SLURM is not caching state properly, but steps
are found to be in FINISHING previous state when seen as UNKNOWN,
mark them complete. Otherwise, mark it unknown, and let the next
step run and fail if the UNKNOWN step failed.