### PR TITLE
Add name and real_name StudyStep properties.

### DIFF
--- a/maestrowf/abstracts/interfaces/scriptadapter.py
+++ b/maestrowf/abstracts/interfaces/scriptadapter.py
@@ -28,7 +28,7 @@
 ###############################################################################
 
 """Abstract Script Interfaces for generating scripts."""
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, abstractproperty
 import logging
 import os
 import six
@@ -121,6 +121,14 @@ class ScriptAdapter(object):
             st = os.stat(restart_path)
             os.chmod(restart_path, st.st_mode | stat.S_IXUSR)
 
+        LOGGER.debug(
+            "---------------------------------\n"
+            "Script path:   %s"
+            "Restart path:  %s"
+            "Scheduled?:    %s"
+            "---------------------------------\n",
+            script_path, restart_path, to_be_scheduled
+        )
         return to_be_scheduled, script_path, restart_path
 
     @abstractmethod
@@ -143,8 +151,16 @@ class ScriptAdapter(object):
         """
         pass
 
-    @property
-    @abstractmethod
+    @abstractproperty
+    def extension(self):
+        """
+        Returns the extension that generated scripts will use.
+
+        :returns: A string of the extension
+        """
+        pass
+
+    @abstractproperty
     def key(self):
         """
         Return the key name for a ScriptAdapter..

--- a/maestrowf/abstracts/interfaces/scriptadapter.py
+++ b/maestrowf/abstracts/interfaces/scriptadapter.py
@@ -123,9 +123,9 @@ class ScriptAdapter(object):
 
         LOGGER.debug(
             "---------------------------------\n"
-            "Script path:   %s"
-            "Restart path:  %s"
-            "Scheduled?:    %s"
+            "Script path:   %s\n"
+            "Restart path:  %s\n"
+            "Scheduled?:    %s\n"
             "---------------------------------\n",
             script_path, restart_path, to_be_scheduled
         )

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -230,7 +230,7 @@ class _StepRecord:
 
         :returns: The name of the StudyStep contained within the record.
         """
-        return self.step.name
+        return self.step.real_name
 
     @property
     def walltime(self):
@@ -386,10 +386,10 @@ class ExecutionGraph(DAG, PickleInterface):
         :param restart_limit: Upper limit on the number of restart attempts.
         """
         data = {
-                    "step": step,
-                    "state": State.INITIALIZED,
-                    "workspace": workspace,
-                    "restart_limit": restart_limit
+                    "step":          step,
+                    "state":         State.INITIALIZED,
+                    "workspace":     workspace,
+                    "restart_limit": restart_limit,
                 }
         record = _StepRecord(**data)
         self._dependencies[name] = set()

--- a/maestrowf/datastructures/core/study.py
+++ b/maestrowf/datastructures/core/study.py
@@ -114,7 +114,7 @@ class StudyStep:
         """
         Set the name of a StudyStep instance.
 
-        :oaram value: A string value representing the name to give the step.
+        :param value: A string value representing the name to give the step.
         """
         self._name = value
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -105,7 +105,12 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             "ntasks": "-n",
             "nodes": "-N",
         }
+        self._extension = "flux.sh"
         self.h = None
+
+    @property
+    def extension(self):
+        return self._extension
 
     def _convert_walltime_to_seconds(self, walltime):
         # Convert walltime to seconds.
@@ -450,7 +455,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
         """
         to_be_scheduled, cmd, restart = self.get_scheduler_command(step)
 
-        fname = "{}.flux.sh".format(step.name)
+        fname = "{}.{}".format(step.name, self._extension)
         script_path = os.path.join(ws_path, fname)
         with open(script_path, "w") as script:
             if to_be_scheduled:
@@ -462,7 +467,7 @@ class SpectrumFluxScriptAdapter(SchedulerScriptAdapter):
             script.write(cmd)
 
         if restart:
-            rname = "{}.restart.flux.sh".format(step.name)
+            rname = "{}.restart.{}".format(step.name, self._extension)
             restart_path = os.path.join(ws_path, rname)
 
             with open(restart_path, "w") as script:
@@ -523,7 +528,12 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             "ntasks": "-n",
             "nodes": "-N",
         }
+        self._extension = "flux.sh"
         self.h = None
+
+    @property
+    def extension(self):
+        return self._extension
 
     def _convert_walltime_to_seconds(self, walltime):
         # Convert walltime to seconds.
@@ -853,7 +863,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         """
         to_be_scheduled, cmd, restart = self.get_scheduler_command(step)
 
-        fname = "{}.flux.sh".format(step.name)
+        fname = "{}.{}".format(step.name, self._extension)
         script_path = os.path.join(ws_path, fname)
         with open(script_path, "w") as script:
             if to_be_scheduled:
@@ -865,7 +875,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             script.write(cmd)
 
         if restart:
-            rname = "{}.restart.flux.sh".format(step.name)
+            rname = "{}.restart.{}".format(step.name, self._extension)
             restart_path = os.path.join(ws_path, rname)
 
             with open(restart_path, "w") as script:

--- a/maestrowf/interfaces/script/localscriptadapter.py
+++ b/maestrowf/interfaces/script/localscriptadapter.py
@@ -57,6 +57,7 @@ class LocalScriptAdapter(ScriptAdapter):
         """
         LOGGER.debug("kwargs\n--------------------------\n%s", kwargs)
         super(LocalScriptAdapter, self).__init__(**kwargs)
+        self._extension = ".sh"
 
     def _write_script(self, ws_path, step):
         """
@@ -154,3 +155,7 @@ class LocalScriptAdapter(ScriptAdapter):
             _record = SubmissionRecord(SubmissionCode.ERROR, retcode, pid)
             _record.add_info("stderr", str(err))
             return _record
+
+    @property
+    def extension(self):
+        return self._extension

--- a/maestrowf/interfaces/script/lsfscriptadapter.py
+++ b/maestrowf/interfaces/script/lsfscriptadapter.py
@@ -95,6 +95,8 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
             "reservation":  "-J",
         }
 
+        self._extension = ".lsf.sh"
+
     def get_header(self, step):
         """
         Generate the header present at the top of LSF execution scripts.
@@ -383,7 +385,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
         """
         to_be_scheduled, cmd, restart = self.get_scheduler_command(step)
 
-        fname = "{}.lsf.cmd".format(step.name)
+        fname = "{}.{}".format(step.name, self._extension)
         script_path = os.path.join(ws_path, fname)
         with open(script_path, "w") as script:
             if to_be_scheduled:
@@ -395,7 +397,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
             script.write(cmd)
 
         if restart:
-            rname = "{}.restart.lsf.cmd".format(step.name)
+            rname = "{}.restart.{}".format(step.name, self._extension)
             restart_path = os.path.join(ws_path, rname)
 
             with open(restart_path, "w") as script:
@@ -410,3 +412,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
             restart_path = None
 
         return to_be_scheduled, script_path, restart_path
+
+    @property
+    def extension(self):
+        return self._extension

--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -106,6 +106,8 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
             "nodes": "-N",
             "cores per task": "-c",
         }
+
+        self._extension = ".slurm.sh"
         self._unsupported = set(["cmd", "depends", "ntasks", "nodes"])
 
     def get_header(self, step):
@@ -378,3 +380,7 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
             restart_path = None
 
         return to_be_scheduled, script_path, restart_path
+
+    @property
+    def extension(self):
+        return self._extension


### PR DESCRIPTION
There now needs to be an aliasing of nickname with a step name when requested because adapters expect to use the name. StudyStep objects now return their nickname if the nickname is set. Objects such as the ExecutionGraph must now use the real_name for logistic tracking, while adapters can continue to use name. The nickname field is then used to fill in hashing nicknames to correct the script generation.

Fixes #291
Fixes #267 