### PR TITLE
Removal of Python 2.7 and addition of newer Python 3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 
 python:
-    - "2.7"
     - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
     - "3.5"
     - "3.6"
-    - "3.7"
     - "3.8"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,8 @@ language: python
 python:
     - "3.5"
     - "3.6"
+    - "3.7"
     - "3.8"
-
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 
 install:
     - pip install tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake, py{27,34,35,36}
+envlist = flake, py{35,36,37,38}
 skip_missing_interpreters=True
 
 [travis]
 python =
-	2.7: py27
 	3.5: py35
 	3.6: py36
+	3.7: py37
+	3.8: py38
 
 [testenv]
 deps:


### PR DESCRIPTION
Maestro will be dropping support for Python 2 in the upcoming release. This PR updates the tests since the `setup.py` file has now been updated and it's causing TravisCI failures in PRs.