### PR TITLE
simple bug fix in the YAMLSpec description setter

### DIFF
--- a/maestrowf/specification/yamlspecification.py
+++ b/maestrowf/specification/yamlspecification.py
@@ -518,7 +518,7 @@ class YAMLSpecification(Specification):
 
         :param value: String value representing the new description.
         """
-        self.description["name"] = value
+        self.description["description"] = value
 
     def get_study_environment(self):
         """


### PR DESCRIPTION
While writing unit tests found a bug that in YAMLSpecification the desc property setter actually changes the name property not description.