### PR TITLE
Addition of cancellation for multiple directories and globs.

### DIFF
--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -103,16 +103,31 @@ def cancel_study(args):
     directory_list = args.directory
 
     ret_code = 0
+    to_cancel = []
     if directory_list:
         for directory in directory_list:
-            if not os.path.isdir(directory):
+            abs_path = os.path.abspath(directory)
+            if not os.path.isdir(abs_path):
                 print(
-                    f"Attempted to cancel '{directory}' "
+                    f"Attempted to cancel '{abs_path}' "
                     "-- study directory not found.")
-                ret_code = 2
+                ret_code = 1
             else:
-                print(f"Marked study in '{directory}' to be cancelled.")
-                Conductor.mark_cancelled(directory)
+                print(f"Study in '{abs_path}' to be cancelled.")
+                to_cancel.append(abs_path)
+
+        if to_cancel:
+            ok_cancel = input("Are you sure? [y|[n]]: ")
+            try:
+                if ok_cancel in ACCEPTED_INPUT:
+                    for directory in to_cancel:
+                        Conductor.mark_cancelled(directory)
+            except Exception as excpt:
+                print(f"Error:\n{excpt}")
+                print("Error in cancellation. Aborting.")
+                return -1
+        else:
+            print("Cancellation aborted.")
     else:
         print("Path(s) or glob(s) did not resolve to a directory(ies).")
         ret_code = 1

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -100,13 +100,24 @@ def cancel_study(args):
     # Force logging to Warning and above
     LOG_UTIL.configure(LFORMAT, log_lvl=3)
 
-    if not os.path.isdir(args.directory):
-        print("Attempted to cancel a path that was not a directory.")
-        return 1
+    directory_list = args.directory
 
-    Conductor.mark_cancelled(args.directory)
+    ret_code = 0
+    if directory_list:
+        for directory in directory_list:
+            if not os.path.isdir(directory):
+                print(
+                    f"Attempted to cancel '{directory}' "
+                    "-- study directory not found.")
+                ret_code = 2
+            else:
+                print(f"Marked study in '{directory}' to be cancelled.")
+                Conductor.mark_cancelled(directory)
+    else:
+        print("Path(s) or glob(s) did not resolve to a directory(ies).")
+        ret_code = 1
 
-    return 0
+    return ret_code
 
 
 def load_parameter_generator(path, env, kwargs):
@@ -341,7 +352,7 @@ def setup_argparser():
         'cancel',
         help="Cancel all running jobs.")
     cancel.add_argument(
-        "directory", type=str,
+        "directory", type=str, nargs="+",
         help="Directory containing a launched study.")
     cancel.set_defaults(func=cancel_study)
 


### PR DESCRIPTION
The `maestro cancel` subcommand now accepts globbing and multiple paths for cancellation. It simply places a cancel lock in each directory just as it did for a single directory previously. Additionally, it will ask the user if they are sure they would like to kill the printed directories before actually canceling.