### PR TITLE
Removal of Python3.5 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">3.4"
+python = ">3.5"
 coloredlogs = "*"
 dill = "*"
 filelock = "*"

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     long_description=load_readme(),
     long_description_content_type='text/markdown',
     download_url='https://pypi.org/project/maestrowf/',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=2.7, >3.5.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Operating System :: Unix',

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ skip_missing_interpreters=True
 
 [travis]
 python =
-	3.5: py35
 	3.6: py36
 	3.7: py37
 	3.8: py38


### PR DESCRIPTION
Python 3.5 is retired and no longer updated -- dropping testing/support for 3.5.