### PR TITLE
Draft: Update pip and tox for 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ tox-pyenv = "*"
 
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=0.12", "cryptography<3"]
 build-backend = "poetry.masonry.api"
 
 


### PR DESCRIPTION
This PR is trying to fix the new 3.6 `cryptography` error that's been popping up.