### PR TITLE
Flux update

### DIFF
--- a/maestrowf/abstracts/interfaces/flux.py
+++ b/maestrowf/abstracts/interfaces/flux.py
@@ -1,8 +1,49 @@
 from abc import ABC, abstractclassmethod, abstractmethod, \
     abstractstaticmethod
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+try:
+    import flux
+except ImportError:
+    LOGGER.info("Failed to import Flux. Continuing.")
 
 
 class FluxInterface(ABC):
+
+    @classmethod
+    def connect_to_flux(cls):
+        if not cls.flux_handle:
+            cls.flux_handle = flux.Flux()
+            LOGGER.debug("New Flux handle created.")
+            broker_version = cls.flux_handle.attr_get("version")
+            adaptor_version = cls.key
+            LOGGER.debug(
+                "Connected to Flux broker running version %s using Maestro "
+                "adapter version %s.", broker_version, adaptor_version)
+            try:
+                from distutils.version import StrictVersion
+                adaptor_version = StrictVersion(adaptor_version)
+                broker_version = StrictVersion(broker_version)
+                if adaptor_version > broker_version:
+                    LOGGER.error(
+                        "Maestro adapter version (%s) is too new for the Flux "
+                        "broker version (%s). Functionality not present in "
+                        "this Flux version may be required by the adapter and "
+                        "cause errors. Please switch to an older adapter.",
+                        adaptor_version, broker_version
+                    )
+                elif adaptor_version < broker_version:
+                    LOGGER.debug(
+                        "Maestro adaptor version (%s) is older than the Flux "
+                        "broker version (%s). This is usually OK, but if a "
+                        "newer Maestro adapter is available, please consider "
+                        "upgrading to maximize performance and compatibility.",
+                        adaptor_version, broker_version
+                    )
+            except ImportError:
+                pass
 
     @abstractclassmethod
     def get_statuses(cls, joblist):

--- a/maestrowf/interfaces/script/_flux/flux0_17_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_17_0.py
@@ -60,9 +60,7 @@ class FluxInterface_0170(FluxInterface):
         cls, nodes, procs, cores_per_task, path, cwd, walltime,
         ngpus=0, job_name=None, force_broker=False
     ):
-        if not cls.flux_handle:
-            cls.flux_handle = flux.Flux()
-            LOGGER.debug("New Flux instance created.")
+        cls.connect_to_flux()
 
         # NOTE: This previously placed everything under a broker. However,
         # if there's a job that schedules items to Flux, it will schedule all
@@ -160,9 +158,7 @@ class FluxInterface_0170(FluxInterface):
     def get_statuses(cls, joblist):
         # We need to import flux here, as it may not be installed on
         # all systems.
-        if not cls.flux_handle:
-            cls.flux_handle = flux.Flux()
-            LOGGER.debug("New Flux instance created.")
+        cls.connect_to_flux()
 
         LOGGER.debug(
             "Handle address -- %s", hex(id(cls.flux_handle)))
@@ -245,9 +241,7 @@ class FluxInterface_0170(FluxInterface):
         """
         # We need to import flux here, as it may not be installed on
         # all systems.
-        if not cls.flux_handle:
-            cls.flux_handle = flux.Flux()
-            LOGGER.debug("New Flux instance created.")
+        cls.connect_to_flux()
 
         LOGGER.debug(
             "Handle address -- %s", hex(id(cls.flux_handle)))

--- a/maestrowf/interfaces/script/_flux/flux0_18_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_18_0.py
@@ -13,7 +13,6 @@ LOGGER = logging.getLogger(__name__)
 try:
     from flux import constants as flux_constants
     from flux import job as flux_job
-    from flux import Flux
 except ImportError:
     LOGGER.info("Failed to import Flux. Continuing.")
 
@@ -64,9 +63,7 @@ class FluxInterface_0190(FluxInterface):
         cls, nodes, procs, cores_per_task, path, cwd, walltime,
         ngpus=0, job_name=None, force_broker=False
     ):
-        if not cls.flux_handle:
-            cls.flux_handle = Flux()
-            LOGGER.debug("New Flux instance created.")
+        cls.connect_to_flux()
 
         # NOTE: This previously placed everything under a broker. However,
         # if there's a job that schedules items to Flux, it will schedule all
@@ -174,9 +171,7 @@ class FluxInterface_0190(FluxInterface):
     def get_statuses(cls, joblist):
         # We need to import flux here, as it may not be installed on
         # all systems.
-        if not cls.flux_handle:
-            cls.flux_handle = Flux()
-            LOGGER.debug("New Flux instance created.")
+        cls.connect_to_flux()
 
         LOGGER.debug(
             "Handle address -- %s", hex(id(cls.flux_handle)))
@@ -257,9 +252,7 @@ class FluxInterface_0190(FluxInterface):
         """
         # We need to import flux here, as it may not be installed on
         # all systems.
-        if not cls.flux_handle:
-            cls.flux_handle = Flux()
-            LOGGER.debug("New Flux instance created.")
+        cls.connect_to_flux()
 
         LOGGER.debug(
             "Handle address -- %s", hex(id(cls.flux_handle)))

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -64,6 +64,9 @@ class FluxInterface_0260(FluxInterface):
         # single node, don't use a broker -- but introduce a flag that can
         # force a single node to run in a broker.
 
+        if isinstance(ngpus, str) and ngpus.isdigit():
+            ngpus = int(ngpus)
+
         if force_broker or nodes > 1:
             LOGGER.debug(
                 "Launch under Flux sub-broker. [force_broker=%s, nodes=%d]",

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -22,39 +22,6 @@ class FluxInterface_0260(FluxInterface):
     flux_handle = None
 
     @classmethod
-    def connect_to_flux(cls):
-        if not cls.flux_handle:
-            cls.flux_handle = flux.Flux()
-            LOGGER.debug("New Flux handle created.")
-            broker_version = cls.flux_handle.attr_get("version")
-            adaptor_version = cls.key
-            LOGGER.debug(
-                "Connected to Flux broker running version %s using Maestro "
-                "adapter version %s.", broker_version, adaptor_version)
-            try:
-                from distutils.version import StrictVersion
-                adaptor_version = StrictVersion(adaptor_version)
-                broker_version = StrictVersion(broker_version)
-                if adaptor_version > broker_version:
-                    LOGGER.error(
-                        "Maestro adapter version (%s) is too new for the Flux "
-                        "broker version (%s). Functionality not present in "
-                        "this Flux version may be required by the adapter and "
-                        "cause errors. Please switch to an older adapter.",
-                        adaptor_version, broker_version
-                    )
-                elif adaptor_version < broker_version:
-                    LOGGER.debug(
-                        "Maestro adaptor version (%s) is older than the Flux "
-                        "broker version (%s). This is usually OK, but if a "
-                        "newer Maestro adapter is available, please consider "
-                        "upgrading to maximize performance and compatibility.",
-                        adaptor_version, broker_version
-                    )
-            except ImportError:
-                pass
-
-    @classmethod
     def submit(
         cls, nodes, procs, cores_per_task, path, cwd, walltime,
         ngpus=0, job_name=None, force_broker=True

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -75,7 +75,7 @@ class FluxInterface_0260(FluxInterface):
             ngpus_per_slot = int(ceil(ngpus / nodes))
             jobspec = flux.job.JobspecV1.from_nest_command(
                 [path], num_nodes=nodes, cores_per_slot=cores_per_task,
-                num_slots=nodes, gpus_per_slot=ngpus_per_slot)
+                num_slots=procs, gpus_per_slot=ngpus_per_slot)
         else:
             LOGGER.debug(
                 "Launch under root Flux broker. [force_broker=%s, nodes=%d]",

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -53,7 +53,7 @@ class FluxInterface_0260(FluxInterface):
     @classmethod
     def submit(
         cls, nodes, procs, cores_per_task, path, cwd, walltime,
-        ngpus=0, job_name=None, force_broker=False
+        ngpus=0, job_name=None, force_broker=True
     ):
         cls.connect_to_flux()
 

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -35,9 +35,6 @@ class FluxInterface_0260(FluxInterface):
         # single node, don't use a broker -- but introduce a flag that can
         # force a single node to run in a broker.
 
-        if isinstance(ngpus, str) and ngpus.isdigit():
-            ngpus = int(ngpus)
-
         if force_broker or nodes > 1:
             LOGGER.debug(
                 "Launch under Flux sub-broker. [force_broker=%s, nodes=%d]",

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -28,23 +28,27 @@ class FluxInterface_0260(FluxInterface):
             LOGGER.debug("New Flux handle created.")
             broker_version = cls.flux_handle.attr_get("version")
             adaptor_version = cls.key
-            LOGGER.debug("Connected to Flux broker running version %s using maestro adaptor version %s.",
-                         broker_version, adaptor_version)
+            LOGGER.debug(
+                "Connected to Flux broker running version %s using Maestro "
+                "adapter version %s.", broker_version, adaptor_version)
             try:
                 from distutils.version import StrictVersion
                 adaptor_version = StrictVersion(adaptor_version)
                 broker_version = StrictVersion(broker_version)
                 if adaptor_version > broker_version:
                     LOGGER.error(
-                        "Maestro adaptor version (%s) is too new for the Flux broker version (%s). "
-                        "Functionality not present in this Flux version may be required by the adaptor and cause errors. "
-                        "Please switch to an older adaptor.",
+                        "Maestro adapter version (%s) is too new for the Flux "
+                        "broker version (%s). Functionality not present in "
+                        "this Flux version may be required by the adapter and "
+                        "cause errors. Please switch to an older adapter.",
                         adaptor_version, broker_version
                     )
                 elif adaptor_version < broker_version:
                     LOGGER.debug(
-                        "Maestro adaptor version (%s) is older than the Flux broker version (%s). "
-                        "This is usually OK, but if a newer Maestro adaptor is available, please consider upgrading to maximize performance and compatibility.",
+                        "Maestro adaptor version (%s) is older than the Flux "
+                        "broker version (%s). This is usually OK, but if a "
+                        "newer Maestro adapter is available, please consider "
+                        "upgrading to maximize performance and compatibility.",
                         adaptor_version, broker_version
                     )
             except ImportError:
@@ -132,9 +136,8 @@ class FluxInterface_0260(FluxInterface):
 
         if "gpus" in kwargs:
             ngpus = str(kwargs["gpus"])
-            if ngpus.isdecimal():
-                args.append("-g")
-                args.append(ngpus)
+            args.append("-g")
+            args.append(ngpus)
 
         # flux has additional arguments that can be passed via the '-o' flag.
         addtl = []

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -172,7 +172,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         # walltime = self._convert_walltime_to_seconds(step.run["walltime"])
         nodes = step.run.get("nodes")
         processors = step.run.get("procs", 0)
-        force_broker = step.run.get("use_broker", False)
+        force_broker = step.run.get("use_broker", True)
         walltime = step.run.get("walltime", "inf")
 
         # Compute cores per task

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -183,9 +183,14 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
                 "'cores per task' set to a non-value. Populating with a "
                 "sensible default. (cores per task = %d", cores_per_task)
 
-        # Calculate ngpus
-        ngpus = step.run.get("gpus", 0)
-        ngpus = 0 if not ngpus else ngpus
+        try:
+            # Calculate ngpus
+            ngpus = step.run.get("gpus", "0")
+            ngpus = int(ngpus)
+        except ValueError as val_error:
+            msg = f"Specified gpus '{ngpus}' is not a decimal value."
+            LOGGER.error(msg)
+            raise val_error
 
         # Calculate nprocs
         ncores = cores_per_task * nodes

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -186,7 +186,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         try:
             # Calculate ngpus
             ngpus = step.run.get("gpus", "0")
-            ngpus = int(ngpus)
+            ngpus = int(ngpus) if ngpus else 0
         except ValueError as val_error:
             msg = f"Specified gpus '{ngpus}' is not a decimal value."
             LOGGER.error(msg)


### PR DESCRIPTION
This PR adds several changes to the 0.26.0 adapter based on experiences with the GMD loop.  In particular:

- set the default value for `force_broker` to `True` to maximize compatibility with other schedulers/backends
- handle errors in the type for `ngpu` in the flux adapter
- flux the number of slots used in the nested Flux case
- add version checking and log an error when the versions (broker vs adapter) are incompatible

I confirmed that the extra logging does not trigger when running 0.26.0 against 0.26.0 and the error is displayed when running against an older Flux (I had 0.19.0 on hand on Pascal):

```
[2021-05-17 21:08:51: DEBUG] [flux0_26_0: 28] New Flux handle created.
[2021-05-17 21:08:51: DEBUG] [flux0_26_0: 32] Connected to Flux broker running version 0.19.0 using maestro adaptor version 0.26.0.
[2021-05-17 21:08:51: ERROR] [flux0_26_0: 42] Maestro adaptor version (0.26) is too new for the Flux broker version (0.19). Functionality not present in this Flux v
ersion may be required by the adaptor and cause errors. Please switch to an older adaptor.
```