### PR TITLE
Update to fix the addition of -g erroneously to flux mini commands

### DIFF
--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -98,10 +98,11 @@ class FluxInterface_0260(FluxInterface):
             args.append("-c")
             args.append(str(kwargs["cores per task"]))
 
-        if "gpus" in kwargs:
-            ngpus = str(kwargs["gpus"])
+        ngpus = kwargs.get("gpus", 0)
+        if ngpus:
+            gpus = str(ngpus)
             args.append("-g")
-            args.append(ngpus)
+            args.append(gpus)
 
         # flux has additional arguments that can be passed via the '-o' flag.
         addtl = []


### PR DESCRIPTION
Recent changes in #359 introduced a bug that only checked for the inclusion of the `gpus` key a step's settings and erroneously allowed the flag's inclusion even when left blank causing malformed scripts to be generated. This PR corrects the underlying checks to exclude the flag in all cases other than when the value is non-zero.