### PR TITLE
Addition of clean up when detecting a cancel.

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -837,6 +837,7 @@ class ExecutionGraph(DAG, PickleInterface):
                     LOGGER.info("Step '%s' was cancelled.", name)
                     self.in_progress.remove(name)
                     record.mark_end(State.CANCELLED)
+                    cleanup_steps.update(self.bfs_subtree(name)[0])
 
             # Let's handle all the failed steps in one go.
             for node in cleanup_steps:


### PR DESCRIPTION
Previously when a cancelled state was detected, it was assumed that Maestro was the entity that marked the cancellation and didn't move steps over to the clean up set for proper marking.