### PR TITLE
Additional flexibility to walltime parsing for Flux

### DIFF
--- a/maestrowf/interfaces/script/_flux/flux0_18_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_18_0.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import errno
 import logging
 from math import ceil
@@ -96,10 +95,8 @@ class FluxInterface_0190(FluxInterface):
         jobspec.cwd = cwd
         jobspec.environment = dict(os.environ)
 
-        if walltime and walltime != "inf":
-            seconds = datetime.strptime(walltime, "%H:%M:%S")
-            seconds = seconds - datetime(1900, 1, 1)
-            jobspec.duration = seconds
+        if walltime > 0:
+            jobspec.duration = walltime
 
         jobspec.stdout = f"{job_name}.{{{{id}}}}.out"
         jobspec.stderr = f"{job_name}.{{{{id}}}}.err"

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import logging
 from math import ceil
 import os
@@ -59,10 +58,8 @@ class FluxInterface_0260(FluxInterface):
         jobspec.cwd = cwd
         jobspec.environment = dict(os.environ)
 
-        if walltime and walltime != "inf":
-            seconds = datetime.strptime(walltime, "%H:%M:%S")
-            seconds = seconds - datetime(1900, 1, 1)
-            jobspec.duration = seconds
+        if walltime > 0:
+            jobspec.duration = walltime
 
         jobspec.stdout = f"{job_name}.{{{{id}}}}.out"
         jobspec.stderr = f"{job_name}.{{{{id}}}}.err"

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -178,11 +178,11 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         :returns: The return status of the submission command and job
                   identiifer.
         """
-        # walltime = self._convert_walltime_to_seconds(step.run["walltime"])
         nodes = step.run.get("nodes")
         processors = step.run.get("procs", 0)
         force_broker = step.run.get("use_broker", True)
-        walltime = step.run.get("walltime", "inf")
+        walltime = \
+            self._convert_walltime_to_seconds(step.run.get("walltime", 0))
 
         # Compute cores per task
         cores_per_task = step.run.get("cores per task", None)

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -28,7 +28,6 @@
 ###############################################################################
 
 """Flux Scheduler interface implementation."""
-from datetime import datetime
 import logging
 from math import ceil
 import os
@@ -106,14 +105,18 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         return self._extension
 
     def _convert_walltime_to_seconds(self, walltime):
-        if not walltime:
+        if not walltime or walltime == "inf":
             LOGGER.debug("Encountered inf walltime!")
-            return "inf"
-        # Convert walltime to seconds.
-        LOGGER.debug("Converting %s to seconds...", walltime)
-        wt = \
-            (datetime.strptime(walltime, "%H:%M:%S") - datetime(1900, 1, 1))
-        return int(wt.total_seconds())
+            return 0
+        elif ":" in walltime:
+            # Convert walltime to seconds.
+            LOGGER.debug("Converting %s to seconds...", walltime)
+            seconds = 0.0
+            for i, value in enumerate(walltime.split(":")[::-1]):
+                seconds += float(value) * (60.0 ** i)
+            return seconds
+        else:
+            return int(float(walltime) * 60.0)
 
     def get_header(self, step):
         """

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -105,9 +105,9 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         return self._extension
 
     def _convert_walltime_to_seconds(self, walltime):
-        if not walltime or walltime == "inf":
-            LOGGER.debug("Encountered inf walltime!")
-            return 0
+        if isinstance(walltime, int) or isinstance(walltime, float):
+            LOGGER.debug("Encountered numeric walltime = %s", str(walltime))
+            return int(float(walltime) * 60.0)
         elif ":" in walltime:
             # Convert walltime to seconds.
             LOGGER.debug("Converting %s to seconds...", walltime)
@@ -115,8 +115,14 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             for i, value in enumerate(walltime.split(":")[::-1]):
                 seconds += float(value) * (60.0 ** i)
             return seconds
+        elif not walltime:
+            return 0
         else:
-            return int(float(walltime) * 60.0)
+            msg = \
+                f"Walltime value '{walltime}' is not an integer or colon-" \
+                f"separated string."
+            LOGGER.error(msg)
+            raise ValueError(msg)
 
     def get_header(self, step):
         """

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -58,7 +58,12 @@
               {"type": "integer", "minimum": 1},
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
-          "walltime": {"type": "string", "minLength": 1},
+          "walltime": {
+            "anyOf": [
+              {"type": "string", "minLength": 1},
+              {"type": "integer", "minimum": 0},
+              {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
+            ]},
           "reservation": {"type": "string", "minLength": 1},
           "exclusive": {
             "anyOf": [


### PR DESCRIPTION
We've recently been hitting a bug where the wall time parsing in the Flux adapter is too rigid and limits a user to a 24 hour cap. Recently, there has been a need to support wall times that are outside the 24 hour range. While fixing the parsing, the wall time can now accept a numeric number of minutes, a 0 for infinite, and colon separated formatting (that now does not need to conform to `HH:MM:SS`).