### PR TITLE
Addition of connection to try/catch to FluxAdapter

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -4,8 +4,10 @@ from datetime import datetime
 import getpass
 import logging
 import os
+import random
 import shutil
 import tempfile
+from time import sleep
 from filelock import FileLock, Timeout
 
 from maestrowf.abstracts import PickleInterface
@@ -599,6 +601,7 @@ class ExecutionGraph(DAG, PickleInterface):
             # Increment the number of restarts we've attempted.
             LOGGER.debug("Completed submission attempt %d", num_restarts)
             num_restarts += 1
+            sleep((random.random() + 1) * num_restarts)
 
         if retcode == SubmissionCode.OK:
             self.in_progress.add(record.name)


### PR DESCRIPTION
During a DAT with @jmast and it turns out that Maestro does not catch when the Flux handle sends a connection reset due to a failed connection. This PR adds an exponential back off to resubmission attempts and a try/catch to the `FluxScriptAdapter.`