### PR TITLE
Flux Adapter Clean up and Addition of Job Priority

### DIFF
--- a/maestrowf/abstracts/enums/__init__.py
+++ b/maestrowf/abstracts/enums/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from enum import Enum
 
 __all__ = (
-    "JobStatusCode", "State", "SubmissionCode", "StepUrgency", "StudyStatus"
+    "JobStatusCode", "State", "SubmissionCode",  "StepPriority", "StudyStatus"
 )
 
 
@@ -80,7 +80,7 @@ class StudyStatus(Enum):
     CANCELLED = 3  # The Study has finished, but was cancelled
 
 
-class StepUrgency(Enum):
+class StepPriority(Enum):
     """Scheduler priority for submitted jobs"""
     HELD = 0
     MINIMAL = 1
@@ -90,18 +90,18 @@ class StepUrgency(Enum):
     EXPEDITE = 5
 
     @classmethod
-    def from_str(cls, urgency: str) -> StepUrgency:
-        _urgency = urgency.lower()
+    def from_str(cls, priority: str) -> StepPriority:
+        _priority = priority.lower()
 
-        if _urgency == "held":
+        if _priority == "held":
             return cls.HELD
-        if _urgency == "minimal":
+        if _priority == "minimal":
             return cls.MINIMAL
-        if _urgency == "medium":
+        if _priority == "medium":
             return cls.MEDIUM
-        if _urgency == "high":
+        if _priority == "high":
             return cls.HIGH
-        if _urgency == "expedite":
+        if _priority == "expedite":
             return cls.EXPEDITE
 
-        raise ValueError(f"Urgency '{urgency}' not valid.")
+        raise ValueError(f"Priority '{priority}' not valid.")

--- a/maestrowf/abstracts/enums/__init__.py
+++ b/maestrowf/abstracts/enums/__init__.py
@@ -75,3 +75,13 @@ class StudyStatus(Enum):
     RUNNING = 1    # The Study is currently running
     FAILURE = 2    # The Study has finished, but 1 or more steps failed
     CANCELLED = 3  # The Study has finished, but was cancelled
+
+
+class StepUrgency(Enum):
+    """Scheduler priority for submitted jobs"""
+    HELD = 0
+    MINIMAL = 1
+    LOW = 2
+    MEDIUM = 3
+    HIGH = 4
+    EXPEDITE = 5

--- a/maestrowf/abstracts/enums/__init__.py
+++ b/maestrowf/abstracts/enums/__init__.py
@@ -28,7 +28,6 @@
 ###############################################################################
 
 """Package for providing enumerations for interfaces"""
-from __future__ import annotations
 from enum import Enum
 
 __all__ = (
@@ -90,7 +89,7 @@ class StepPriority(Enum):
     EXPEDITE = 5
 
     @classmethod
-    def from_str(cls, priority: str) -> StepPriority:
+    def from_str(cls, priority):
         _priority = priority.lower()
 
         if _priority == "held":

--- a/maestrowf/abstracts/enums/__init__.py
+++ b/maestrowf/abstracts/enums/__init__.py
@@ -28,9 +28,12 @@
 ###############################################################################
 
 """Package for providing enumerations for interfaces"""
+from __future__ import annotations
 from enum import Enum
 
-__all__ = ("JobStatusCode", "State", "SubmissionCode", "StudyStatus")
+__all__ = (
+    "JobStatusCode", "State", "SubmissionCode", "StepUrgency", "StudyStatus"
+)
 
 
 class SubmissionCode(Enum):
@@ -85,3 +88,20 @@ class StepUrgency(Enum):
     MEDIUM = 3
     HIGH = 4
     EXPEDITE = 5
+
+    @classmethod
+    def from_str(cls, urgency: str) -> StepUrgency:
+        _urgency = urgency.lower()
+
+        if _urgency == "held":
+            return cls.HELD
+        if _urgency == "minimal":
+            return cls.MINIMAL
+        if _urgency == "medium":
+            return cls.MEDIUM
+        if _urgency == "high":
+            return cls.HIGH
+        if _urgency == "expedite":
+            return cls.EXPEDITE
+
+        raise ValueError(f"Urgency '{urgency}' not valid.")

--- a/maestrowf/abstracts/interfaces/flux.py
+++ b/maestrowf/abstracts/interfaces/flux.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractclassmethod, abstractmethod, \
     abstractstaticmethod
 import logging
 
+from maestrowf.abstracts.enums import StepUrgency
+
 LOGGER = logging.getLogger(__name__)
 
 try:
@@ -78,7 +80,7 @@ class FluxInterface(ABC):
     @abstractclassmethod
     def submit(
         cls, nodes, procs, cores_per_task, path, cwd, walltime,
-        npgus=0, job_name=None, force_broker=False
+        npgus=0, job_name=None, force_broker=False, urgency=StepUrgency.MEDIUM
     ):
         """
         Submit a job using this Flux interface's submit API.
@@ -92,6 +94,7 @@ class FluxInterface(ABC):
         :param ngpus: The number of GPUs to request on submission.
         :param job_name: A name string to assign the submitted job.
         :param force_broker: Forces the script to run under a Flux sub-broker.
+        :param urgency: Enumerated scheduling priority for the submitted job.
         :return: A string representing the jobid returned by Flux submit.
         :return: An integer of the return code submission returned.
         :return: SubmissionCode enumeration that reflects result of submission.

--- a/maestrowf/abstracts/interfaces/flux.py
+++ b/maestrowf/abstracts/interfaces/flux.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import logging
 
-from maestrowf.abstracts.enums import StepUrgency
+from maestrowf.abstracts.enums import StepPriority
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class FluxInterface(ABC):
         """
         Map a fixed enumeration or floating point priority to a Flux urgency.
 
-        :param priority: Float or StepUrgency enum representing priorty.
+        :param priority: Float or StepPriority enum representing priorty.
         :returns: An integery mapping the urgency parameter to a Flux urgency.
         """
         raise NotImplementedError()
@@ -97,7 +97,7 @@ class FluxInterface(ABC):
     @abstractmethod
     def submit(
         cls, nodes, procs, cores_per_task, path, cwd, walltime,
-        npgus=0, job_name=None, force_broker=False, urgency=StepUrgency.MEDIUM
+        npgus=0, job_name=None, force_broker=False, urgency=StepPriority.MEDIUM
     ):
         """
         Submit a job using this Flux interface's submit API.

--- a/maestrowf/abstracts/interfaces/flux.py
+++ b/maestrowf/abstracts/interfaces/flux.py
@@ -1,5 +1,4 @@
-from abc import ABC, abstractclassmethod, abstractmethod, \
-    abstractstaticmethod
+from abc import ABC, abstractmethod
 import logging
 
 from maestrowf.abstracts.enums import StepUrgency
@@ -47,7 +46,19 @@ class FluxInterface(ABC):
             except ImportError:
                 pass
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
+    def get_flux_urgency(cls, urgency) -> int:
+        """
+        Map a fixed enumeration or floating point priority to a Flux urgency.
+
+        :param priority: Float or StepUrgency enum representing priorty.
+        :returns: An integery mapping the urgency parameter to a Flux urgency.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
     def get_statuses(cls, joblist):
         """
         Return the statuses from a given Flux handle and joblist.
@@ -55,8 +66,10 @@ class FluxInterface(ABC):
         :param joblist: A list of jobs to check the status of.
         :return: A dictionary of job identifiers to statuses.
         """
+        ...
 
-    @abstractstaticmethod
+    @classmethod
+    @abstractmethod
     def state(state):
         """
         Map a scheduler specific job state to a Study.State enum.
@@ -65,8 +78,10 @@ class FluxInterface(ABC):
         :param state: A string of the state returned by Flux
         :return: The mapped Study.State enumeration
         """
+        ...
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def parallelize(cls, procs, nodes=None, **kwargs):
         """
         Create a parallelized Flux command for launching.
@@ -76,8 +91,10 @@ class FluxInterface(ABC):
         :param kwargs: Extra keyword arguments.
         :return: A string of a Flux MPI command.
         """
+        ...
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def submit(
         cls, nodes, procs, cores_per_task, path, cwd, walltime,
         npgus=0, job_name=None, force_broker=False, urgency=StepUrgency.MEDIUM
@@ -99,8 +116,10 @@ class FluxInterface(ABC):
         :return: An integer of the return code submission returned.
         :return: SubmissionCode enumeration that reflects result of submission.
         """
+        ...
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def cancel(cls, joblist):
         """
         Cancel a job using this Flux interface's cancellation API.
@@ -108,6 +127,7 @@ class FluxInterface(ABC):
         :param joblist: A list of job identifiers to cancel.
         :return: CancelCode enumeration that reflects result of cancellation.
         """
+        ...
 
     @property
     @abstractmethod
@@ -120,3 +140,4 @@ class FluxInterface(ABC):
 
         :return: A string of the name of a FluxInterface class.
         """
+        ...

--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -335,7 +335,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
         """
         Map a fixed enumeration or floating point priority to a batch priority.
 
-        :param priority: Float or StepUrgency enum representing priorty.
+        :param priority: Float or StepPriority enum representing priorty.
         :returns: A string, integer, or float value representing the mapped
         priority to the batch scheduler.
         """

--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -330,3 +330,13 @@ class SchedulerScriptAdapter(ScriptAdapter):
         :returns: A Study.State enum corresponding to parameter job_state.
         """
         pass
+
+    def get_priority(self, priority):
+        """
+        Map a fixed enumeration or floating point priority to a batch priority.
+
+        :param priority: Float or StepUrgency enum representing priorty.
+        :returns: A string, integer, or float value representing the mapped
+        priority to the batch scheduler.
+        """
+        raise NotImplementedError()

--- a/maestrowf/datastructures/core/parameters.py
+++ b/maestrowf/datastructures/core/parameters.py
@@ -329,8 +329,6 @@ class ParameterGenerator:
         """
         if not item:
             return
-        elif isinstance(item, int):
-            return
         elif isinstance(item, str):
             for key in self.parameters.keys():
                 _ = r"\{}\({}\.*\w*\)".format(self.token, key)
@@ -344,10 +342,11 @@ class ParameterGenerator:
             for each in item.values():
                 self._get_used_parameters(each, params)
         else:
-            msg = "Encountered an object of type '{}'. Expected a str, list," \
-                  " int, or dict.".format(type(item))
-            logger.error(msg)
-            raise ValueError(msg)
+            msg = \
+                "Encountered an object of type '{}'. Passing."\
+                .format(type(item))
+            logger.debug(msg)
+            return
 
     def get_used_parameters(self, step):
         """

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -30,9 +30,15 @@ class FluxInterface_0260(FluxInterface):
 
     @classmethod
     def get_flux_urgency(cls, urgency) -> int:
+        if isinstance(urgency, str):
+            LOGGER.debug("Found string urgency: %s", urgency)
+            urgency = StepPriority.from_str(urgency)
+
         if isinstance(urgency, StepPriority):
+            LOGGER.debug("StepUrgency urgency of '%s' given..", urgency)
             return cls._urgencies[urgency]
         else:
+            LOGGER.debug("Float urgency of '%s' given..", urgency)
             return ceil(float(urgency) * 31)
 
     @classmethod
@@ -83,7 +89,7 @@ class FluxInterface_0260(FluxInterface):
             # Submit our job spec.
             jobid = flux.job.submit(
                 cls.flux_handle, jobspec, waitable=True,
-                urgency=cls._get_flux_urgency(urgency)
+                urgency=urgency
             )
             submit_status = SubmissionCode.OK
             retcode = 0

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -3,7 +3,7 @@ from math import ceil
 import os
 
 from maestrowf.abstracts.enums import CancelCode, JobStatusCode, State, \
-    StepUrgency, SubmissionCode
+    StepPriority, SubmissionCode
 from maestrowf.abstracts.interfaces.flux import FluxInterface
 
 LOGGER = logging.getLogger(__name__)
@@ -20,17 +20,17 @@ class FluxInterface_0260(FluxInterface):
 
     flux_handle = None
     _urgencies = {
-        StepUrgency.HELD:     0,
-        StepUrgency.MINIMAL:  1,
-        StepUrgency.LOW:      9,
-        StepUrgency.MEDIUM:   16,
-        StepUrgency.HIGH:     24,
-        StepUrgency.EXPEDITE: 31,
+        StepPriority.HELD:     0,
+        StepPriority.MINIMAL:  1,
+        StepPriority.LOW:      9,
+        StepPriority.MEDIUM:   16,
+        StepPriority.HIGH:     24,
+        StepPriority.EXPEDITE: 31,
     }
 
     @classmethod
     def get_flux_urgency(cls, urgency) -> int:
-        if isinstance(urgency, StepUrgency):
+        if isinstance(urgency, StepPriority):
             return cls._urgencies[urgency]
         else:
             return ceil(float(urgency) * 31)
@@ -38,7 +38,7 @@ class FluxInterface_0260(FluxInterface):
     @classmethod
     def submit(
         cls, nodes, procs, cores_per_task, path, cwd, walltime,
-        ngpus=0, job_name=None, force_broker=True, urgency=StepUrgency.MEDIUM
+        ngpus=0, job_name=None, force_broker=True, urgency=StepPriority.MEDIUM
     ):
         try:
             cls.connect_to_flux()

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -20,8 +20,8 @@ class FluxInterface_0260(FluxInterface):
 
     flux_handle = None
     _urgencies = {
-        StepUrgency.HELD:     1,
-        StepUrgency.MINIMAL:  2,
+        StepUrgency.HELD:     0,
+        StepUrgency.MINIMAL:  1,
         StepUrgency.LOW:      9,
         StepUrgency.MEDIUM:   16,
         StepUrgency.HIGH:     24,

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -29,8 +29,11 @@ class FluxInterface_0260(FluxInterface):
     }
 
     @classmethod
-    def _get_flux_urgency(cls, urgency: StepUrgency) -> int:
-        return cls._urgencies[urgency]
+    def get_flux_urgency(cls, urgency) -> int:
+        if isinstance(urgency, StepUrgency):
+            return cls._urgencies[urgency]
+        else:
+            return ceil(float(urgency) * 31)
 
     @classmethod
     def submit(

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -35,7 +35,7 @@ class FluxInterface_0260(FluxInterface):
             # for a single node, don't use a broker -- but introduce a flag
             # that can force a single node to run in a broker.
 
-            if force_broker or nodes > 1:
+            if force_broker:
                 LOGGER.debug(
                     "Launch under Flux sub-broker. [force_broker=%s, "
                     "nodes=%d]", force_broker, nodes

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -34,7 +34,7 @@ import os
 import re
 
 from maestrowf.abstracts.interfaces import SchedulerScriptAdapter
-from maestrowf.abstracts.enums import JobStatusCode, CancelCode
+from maestrowf.abstracts.enums import JobStatusCode, CancelCode, StepUrgency
 from maestrowf.interfaces.script import CancellationRecord, SubmissionRecord, \
     FluxFactory
 
@@ -186,6 +186,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         force_broker = step.run.get("nested", False)
         walltime = \
             self._convert_walltime_to_seconds(step.run.get("walltime", 0))
+        urgency = StepUrgency.from_str(step.run.get("urgency", "medium"))
 
         # Compute cores per task
         cores_per_task = step.run.get("cores per task", None)
@@ -224,7 +225,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         jobid, retcode, submit_status = \
             self._interface.submit(
                 nodes, processors, cores_per_task, path, cwd, walltime, ngpus,
-                job_name=step.name, force_broker=force_broker
+                job_name=step.name, force_broker=force_broker, urgency=urgency
             )
 
         return SubmissionRecord(submit_status, retcode, jobid)

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -108,7 +108,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         if isinstance(walltime, int) or isinstance(walltime, float):
             LOGGER.debug("Encountered numeric walltime = %s", str(walltime))
             return int(float(walltime) * 60.0)
-        elif isinstance(walltime, str) and walltime.isdigit():
+        elif isinstance(walltime, str) and walltime.isnumeric():
             LOGGER.debug("Encountered numeric walltime = %s", str(walltime))
             return int(float(walltime) * 60.0)
         elif ":" in walltime:

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -96,8 +96,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         self.h = None
         # Store the interface we're using
         _version = kwargs.pop("version", FluxFactory.latest)
-        self.add_batch_parameter(
-            "version", _version)
+        self.add_batch_parameter("version", _version)
         self._interface = FluxFactory.get_interface(_version)
 
     @property
@@ -186,7 +185,11 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         force_broker = step.run.get("nested", False)
         walltime = \
             self._convert_walltime_to_seconds(step.run.get("walltime", 0))
-        urgency = StepUrgency.from_str(step.run.get("urgency", "medium"))
+        urgency = step.run.get("urgency", "medium")
+
+        if isinstance(urgency, str):
+            urgency = self.get_priority(StepUrgency.from_str(urgency))
+        urgency = self.get_priority(urgency)
 
         # Compute cores per task
         cores_per_task = step.run.get("cores per task", None)
@@ -329,3 +332,6 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             restart_path = None
 
         return to_be_scheduled, script_path, restart_path
+
+    def get_priority(self, priority):
+        return self._interface.get_flux_urgency(priority)

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -183,7 +183,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         """
         nodes = step.run.get("nodes")
         processors = step.run.get("procs", 0)
-        force_broker = step.run.get("use_broker", True)
+        force_broker = step.run.get("nested", False)
         walltime = \
             self._convert_walltime_to_seconds(step.run.get("walltime", 0))
 

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -108,6 +108,9 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         if isinstance(walltime, int) or isinstance(walltime, float):
             LOGGER.debug("Encountered numeric walltime = %s", str(walltime))
             return int(float(walltime) * 60.0)
+        elif isinstance(walltime, str) and walltime.isdigit():
+            LOGGER.debug("Encountered numeric walltime = %s", str(walltime))
+            return int(float(walltime) * 60.0)
         elif ":" in walltime:
             # Convert walltime to seconds.
             LOGGER.debug("Converting %s to seconds...", walltime)
@@ -115,7 +118,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             for i, value in enumerate(walltime.split(":")[::-1]):
                 seconds += float(value) * (60.0 ** i)
             return seconds
-        elif not walltime:
+        elif not walltime or (isinstance(walltime, str) and walltime == "inf"):
             return 0
         else:
             msg = \

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -34,7 +34,7 @@ import os
 import re
 
 from maestrowf.abstracts.interfaces import SchedulerScriptAdapter
-from maestrowf.abstracts.enums import JobStatusCode, CancelCode, StepUrgency
+from maestrowf.abstracts.enums import JobStatusCode, CancelCode, StepPriority
 from maestrowf.interfaces.script import CancellationRecord, SubmissionRecord, \
     FluxFactory
 
@@ -185,10 +185,10 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         force_broker = step.run.get("nested", False)
         walltime = \
             self._convert_walltime_to_seconds(step.run.get("walltime", 0))
-        urgency = step.run.get("urgency", "medium")
+        urgency = step.run.get("priority", "medium")
 
         if isinstance(urgency, str):
-            urgency = self.get_priority(StepUrgency.from_str(urgency))
+            urgency = self.get_priority(StepPriority.from_str(urgency))
         urgency = self.get_priority(urgency)
 
         # Compute cores per task

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -207,14 +207,6 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
 
         # Calculate nprocs
         ncores = cores_per_task * nodes
-        # Check to make sure that cores_per_task matches if processors
-        # is specified.
-        if processors > 0 and processors > ncores:
-            msg = "Calculated ncores (nodes * cores per task) = {} " \
-                  "-- procs = {}".format(ncores, processors)
-            LOGGER.error(msg)
-            raise ValueError(msg)
-
         # Raise an exception if ncores is 0
         if ncores <= 0:
             msg = "Invalid number of cores specified. " \

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -34,7 +34,7 @@ import os
 import re
 
 from maestrowf.abstracts.interfaces import SchedulerScriptAdapter
-from maestrowf.abstracts.enums import JobStatusCode, CancelCode, StepPriority
+from maestrowf.abstracts.enums import JobStatusCode, CancelCode
 from maestrowf.interfaces.script import CancellationRecord, SubmissionRecord, \
     FluxFactory
 
@@ -186,9 +186,6 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         walltime = \
             self._convert_walltime_to_seconds(step.run.get("walltime", 0))
         urgency = step.run.get("priority", "medium")
-
-        if isinstance(urgency, str):
-            urgency = self.get_priority(StepPriority.from_str(urgency))
         urgency = self.get_priority(urgency)
 
         # Compute cores per task

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -72,15 +72,14 @@
             ]},
           "nested": {"type": "boolean"},
           "urgency": {
-            "type": "string",
-            "enum": [
-              "HELD",
-              "MINIMAL",
-              "LOW",
-              "MEDIUM",
-              "HIGH",
-              "EXPEDITED"
-            ]},
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["HELD", "MINIMAL", "LOW", "MEDIUM", "HIGH", "EXPEDITED"]
+              },
+              {"type": "number", "minimum": 0.0, "maximum": 1.0}
+            ]
+          },
           "qos": {"type": "string", "minLength": 1}
         },
         "additionalProperties": false,

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -75,7 +75,11 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": ["held", "minimal", "low", "medium", "high", "expedited"]
+                "enum": [
+                  "HELD", "MINIMAL", "LOW", "MEDIUM", "HIGH", "EXPEDITED",
+                  "held", "minimal", "low", "medium", "high", "expedited",
+                  "Held", "Minimal", "Low", "Medium", "High", "Expedited"
+                ]
               },
               {"type": "number", "minimum": 0.0, "maximum": 1.0}
             ]

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -70,7 +70,7 @@
               {"type": "boolean"},
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
-          "use_broker": {"type": "boolean"},
+          "nested": {"type": "boolean"},
           "qos": {"type": "string", "minLength": 1}
         },
         "additionalProperties": false,

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -75,7 +75,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": ["HELD", "MINIMAL", "LOW", "MEDIUM", "HIGH", "EXPEDITED"]
+                "enum": ["held", "minimal", "low", "medium", "high", "expedited"]
               },
               {"type": "number", "minimum": 0.0, "maximum": 1.0}
             ]

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -71,7 +71,7 @@
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
           "nested": {"type": "boolean"},
-          "urgency": {
+          "priority": {
             "anyOf": [
               {
                 "type": "string",

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -71,6 +71,16 @@
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
           "nested": {"type": "boolean"},
+          "urgency": {
+            "type": "string",
+            "enum": [
+              "HELD",
+              "MINIMAL",
+              "LOW",
+              "MEDIUM",
+              "HIGH",
+              "EXPEDITED"
+            ]},
           "qos": {"type": "string", "minLength": 1}
         },
         "additionalProperties": false,

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -146,8 +146,8 @@ def apply_function(item, func):
     else:
         msg = "Encountered an object of type '{}'. Expected a str, list, int" \
               ", or dict.".format(type(item))
-        LOGGER.error(msg)
-        raise ValueError(msg)
+        LOGGER.warning(msg)
+        # raise ValueError(msg)
 
 
 def csvtable_to_dict(fstream):

--- a/maestrowf/utils.py
+++ b/maestrowf/utils.py
@@ -141,13 +141,12 @@ def apply_function(item, func):
     elif isinstance(item, dict):
         return {
             key: apply_function(value, func) for key, value in item.items()}
-    elif isinstance(item, int):
-        return item
     else:
-        msg = "Encountered an object of type '{}'. Expected a str, list, int" \
-              ", or dict.".format(type(item))
-        LOGGER.warning(msg)
-        # raise ValueError(msg)
+        msg = \
+            "Encountered an object of type '{}'. Passing." \
+            .format(type(item))
+        LOGGER.debug(msg)
+        return item
 
 
 def csvtable_to_dict(fstream):

--- a/samples/lulesh/lulesh_sample1_unix_flux.yaml
+++ b/samples/lulesh/lulesh_sample1_unix_flux.yaml
@@ -42,7 +42,8 @@ study:
           nodes: 1
           procs: 1
           cores per task: 1
-          use_broker: True
+          nested: True
+          priority: high
           walltime: "00:02:00"
 
 global.parameters:


### PR DESCRIPTION
This PR cleans up some things and adds to the `FluxScriptAdapter`:
+ Renamed `use_broker` in the YAML specification to `nested` to better match with Flux's externally used terminology.
+ Addition of `urgency` to the YAML specification for job priority.
+ A fix for `inf` wall time for the `FluxScriptAdapter` that previously caused an exception when dealing with string based digits.