### PR TITLE
Avoid overriding previous lines in Lulesh example

### DIFF
--- a/samples/documentation/lulesh_sample1_unix_commented.yaml
+++ b/samples/documentation/lulesh_sample1_unix_commented.yaml
@@ -146,8 +146,8 @@ study:
           # In this case, it points to './sample_output/lulesh/run-lulesh'.
           cmd: |
             echo "Unparameterized step with Parameter Independent dependencies." >> out.log
-            echo $(run-lulesh.workspace) > out.log
-            ls $(run-lulesh.workspace) > ls.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) >> out.log
           # The 'post-process-lulesh' step is dependent on the completion of
           # all parameterizations of 'run-lulesh' as represented by the '_*'.
           # Because this step is not parameterized, it is a singular step that
@@ -161,7 +161,7 @@ study:
             echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "TRIAL = $(TRIAL)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
-            ls $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) >> out.log
           # 'post-process-lulesh-trials' like 'post-process-lulesh' is dependent
           # on all parameterizations of 'run-lulesh'. In this case, because this
           # step is parameterized based on $(TRIALS), there will be a version of

--- a/samples/lulesh/lulesh_sample1_macosx.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx.yaml
@@ -52,8 +52,8 @@ study:
       run:
           cmd: |
             echo "Unparameterized step with Parameter Independent dependencies." >> out.log
-            echo $(run-lulesh.workspace) > out.log
-            ls $(run-lulesh.workspace) > ls.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh_*]
 
     - name: post-process-lulesh-trials
@@ -63,7 +63,7 @@ study:
             echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "TRIAL = $(TRIAL)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
-            ls $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh_*]
 
     - name: post-process-lulesh-size

--- a/samples/lulesh/lulesh_sample1_macosx_linear.yaml
+++ b/samples/lulesh/lulesh_sample1_macosx_linear.yaml
@@ -45,8 +45,8 @@ study:
       run:
           cmd: |
             echo "Unparameterized step with Parameter Independent dependencies." >> out.log
-            echo $(run-lulesh.workspace) > out.log
-            ls $(run-lulesh.workspace) > ls.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh]
 
     - name: post-process-lulesh-trials
@@ -56,7 +56,7 @@ study:
             echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "TRIAL = $(TRIAL)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
-            ls $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh]
 
     - name: post-process-lulesh-size

--- a/samples/lulesh/lulesh_sample1_unix.yaml
+++ b/samples/lulesh/lulesh_sample1_unix.yaml
@@ -49,8 +49,8 @@ study:
       run:
           cmd: |
             echo "Unparameterized step with Parameter Independent dependencies." >> out.log
-            echo $(run-lulesh.workspace) > out.log
-            ls $(run-lulesh.workspace) > ls.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh_*]
 
     - name: post-process-lulesh-trials

--- a/samples/lulesh/lulesh_sample1_unix_linear.yaml
+++ b/samples/lulesh/lulesh_sample1_unix_linear.yaml
@@ -46,8 +46,8 @@ study:
       run:
           cmd: |
             echo "Unparameterized step with Parameter Independent dependencies." >> out.log
-            echo $(run-lulesh.workspace) > out.log
-            ls $(run-lulesh.workspace) > ls.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh]
 
     - name: post-process-lulesh-trials
@@ -57,7 +57,7 @@ study:
             echo "Parameterized step that has Parameter Independent dependencies" >> out.log
             echo "TRIAL = $(TRIAL)" >> out.log
             echo $(run-lulesh.workspace) >> out.log
-            ls $(run-lulesh.workspace) > out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh]
 
     - name: post-process-lulesh-size

--- a/tests/specification/test_specs/lulesh_sample1_unix.yml
+++ b/tests/specification/test_specs/lulesh_sample1_unix.yml
@@ -54,8 +54,8 @@ study:
       run:
           cmd: |
             echo "Unparameterized step with Parameter Independent dependencies." >> out.log
-            echo $(run-lulesh.workspace) > out.log
-            ls $(run-lulesh.workspace) > ls.log
+            echo $(run-lulesh.workspace) >> out.log
+            ls $(run-lulesh.workspace) >> out.log
           depends: [run-lulesh_*]
 
     - name: post-process-lulesh-trials


### PR DESCRIPTION
I was taking a look at the `Lulesh` example to better understand the inner workings of `maestro` and was a little confused because of the file outputs. I think the changes in this PR are necessary to avoid confusing file outputs.

The results differ in as follows:

**Previous file output:**
```bash
ITER.10.SIZE.10
ITER.10.SIZE.20
ITER.10.SIZE.30
ITER.20.SIZE.10
ITER.20.SIZE.20
ITER.20.SIZE.30
ITER.30.SIZE.10
ITER.30.SIZE.20
ITER.30.SIZE.30
```

**New file output:**
```
Parameterized step that has Parameter Independent dependencies
TRIAL = 2
/Users/tobias/tmp2/maestrowf/tests/lulesh/run-lulesh
ITER.10.SIZE.10
ITER.10.SIZE.20
ITER.10.SIZE.30
ITER.20.SIZE.10
ITER.20.SIZE.20
ITER.20.SIZE.30
ITER.30.SIZE.10
ITER.30.SIZE.20
ITER.30.SIZE.30
```

Hope that makes sense :)