### PR TITLE
Enable more complete configurability of jsrun launcher

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -107,6 +107,7 @@ And, running the study is still as simple as:
    quick_start
    hello_world
    lulesh_breakdown
+   schedulers
    parameters
    maestro_core
 

--- a/docs/source/lulesh_breakdown.rst
+++ b/docs/source/lulesh_breakdown.rst
@@ -2,3 +2,82 @@ LULESH Specification Breakdown
 ===============================
 
 Stub
+
+Vanilla Unix/Linux Specification
+++++++++++++++++++++++++++++++++
+
+Stub
+
+Parallel Specifications
++++++++++++++++++++++++
+
+The next three variants of the Lulesh example make changes to enable running the steps
+on HPC clusters using a variety of schedulers, as well as invoking the various parallel
+options in Lulesh itself (MPI, OpenMP, ...).
+
+Slurm Scheduled
+---------------
+
+Stub
+
+Flux Scheduled
+--------------
+
+Stub
+
+LSF Scheduled Parallel Specification
+------------------------------------
+
+This example is configured for running on LLNL's IBM/nVidia HPC machines which use the
+LSF job scheduler to manage compute resources.  Due to variations in system setups this
+may not work on all LSF installations and may require some tweaking to account for the
+differences.  As with the other parallel specifications, adjust the machine name, bank,
+and queue's to suit the system you run this spec on.
+
+
+First change, the batch block to use the LSF scheduler to get appropriate batch submission
+and parallel command injection working:
+
+.. literalinclude:: ../../samples/lulesh/lulesh_sample1_unix_lsf.yaml
+   :language: yaml
+   :lines: 18-22
+   :emphasize-lines: 2
+
+We'll briefly skip ahead to the parameters block as there's multiple different parameters
+used to specify all three modes of running.  ``TASKS`` specifies the mpi tasks, while
+``CPUS_PER_TASK`` captures the openmp threads inside each task.  These can be nested
+but here we are only showing the pure-mpi and pure-openmp modes of Lulesh:
+
+.. literalinclude:: ../../samples/lulesh/lulesh_sample1_unix_lsf.yaml
+   :language: yaml
+   :lines: 80-99
+   :emphasize-lines: 10-12, 14-16
+                     
+
+There are a few differences in the first step to deal with the llnl system where we are
+using the lmod setup to select the mpi and compiler installs to use.  In
+addition, we see the resource keys which have a few differences owing to the
+way LSF describes resources using resource sets (rs).  In this step it's not very important
+yet as the compilation doesn't need to run in parallel.  Note the depends is empty as
+this is the first step that needs to run and has no dependencies.
+
+.. literalinclude:: ../../samples/lulesh/lulesh_sample1_unix_lsf.yaml
+   :language: yaml
+   :lines: 25-48
+   :emphasize-lines: 5-11, 18-24           
+
+
+The run step gets a little more interesting now that we are mixing serial, mpi parallel, and
+openmp parallel modes in a single step.  The biggest difference here is that some of the
+resource parameters get used in the step to set the environment variables needed to control
+the OpenMP thread counts using the ``$(CPUS_PER_TASK)`` Maestro parameter.
+
+.. literalinclude:: ../../samples/lulesh/lulesh_sample1_unix_lsf.yaml
+   :language: yaml
+   :lines: 51-77
+   :emphasize-lines: 16-18, 21-27
+
+And finally, we have the complete specification here
+
+.. literalinclude:: ../../samples/lulesh/lulesh_sample1_unix_lsf.yaml
+   :language: yaml

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -1,0 +1,62 @@
+Scheduling Studies (a.k.a. the Batch Block)
+===========================================
+
+LSF: a Tale of Two Launchers
+****************************
+
+The LSF scheduler has multiple options for the parallel launcher commands:
+
+* `lsrun <https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=jobs-run-interactive-tasks>`_
+* `jsrun <https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=SSWRJV_10.1.0/jsm/jsrun.html>`_
+
+Maestro currently supports only the jsrun version, which differs from slurm
+via a more flexible specification of resources available for each task.  In
+addition to the `procs`, `cores per task`, and `gpu` keys, there are also
+`tasks_per_rs` and `rs_per_node`.  `jsrun` describes things in terms of resource
+sets, with several keywords controlling these resource sets and mapping them to
+the actual machine/node allocations:
+
+* --nrs, -n:  Number of resource sets
+
+* --tasks_per_rs, -a: Number of MPI tasks (ranks) in a resource set
+
+* --cpu_per_rs, -c: Number of physical CPU cores in a resource set
+
+* --gpu_per_rs, -g: Number of GPU's per resource set
+
+* --bind, -b: Specifies binding of tasks within a resource set
+
+* --rs_per_host, -r: Number of resource sets per node 
+
+Now for a few examples of how to map these to Maestro's resource specifications.
+Note the `node` key is not directly used for any of these, but is still used for
+the reservation itself.  The rest of the keys serve to control the per task resources
+and then the per node packing of resource sets.  Consider a few examples:
+
+* 1 resource set per gpu on a cluster with 4 gpus per node with an application requesting
+  8 gpus.  This will consume 2 full nodes of the cluster with 1 MPI rank associated with
+  each gpu and having 1 cpu each.
+
+  .. code-block:: bash
+
+     jsrun -nrs 8 -a 1 -c 1 -g 1 -r 4 my_awesome_gpu_application
+
+
+* 1 resource set per cpu, with no gpus, and using all 44 cpus on the node
+
+  .. code-block:: bash
+
+     jsrun -nrs 44 -a 1 -c 1 -g 0 -r 44 my_awesome_mpi_cpu_application
+
+* Several multithreaded mpi ranks per node, with no gpus
+
+  .. code-block:: bash
+
+     jsrun -nrs 4 -a 1 -c 11 -g 0 -r 4 my_awesome_omp_mpi_cpu_application
+
+* Several multithreaded mpi ranks per node with one gpu per rank, spanning multiple
+  nodes having 4 gpu's each
+
+  .. code-block:: bash
+
+     jsrun -nrs 8 -a 1 -c 11 -g 1 -r 4 my_awesome_all_the_threads_application

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -25,31 +25,31 @@ the actual machine/node allocations:
    * - -n, --nrs
      - procs
      - number of resource sets
-     -
+     - 1
    * - -a, --tasks_per_rs
-     - tasks_per_rs
+     - tasks per rs
      - Number of MPI tasks (ranks) in a resource
-     - 
+     - 1
    * - -c, --cpu_per_rs
      - cores per task
      - Number of physical CPU cores in a resource set
-     - 
+     - 1
    * - -g, --gpu_per_rs
      - gpus
      - Number of GPU's per resource set
-     - 
+     - 0
    * - -b, --bind
-     -
+     - bind
      - Controls binding of tasks in a resource set
-     - 
+     - 'rs'
    * - -B, --bind_gpus
-     -
+     - bind gpus
      - Controls binding of tasks to GPU's in a resource set
-     - 
+     - 'none'
    * - -r, --rs_per_host
-     - rs_per_node
+     - rs per node
      - Number of resource sets per node
-     -
+     - 1
      
 
 Now for a few examples of how to map these to Maestro's resource specifications.

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -52,6 +52,10 @@ the actual machine/node allocations:
      - 1
      
 
+.. note::
+
+   ``bind_gpus`` is new in lsf 10.1 and may not be available on all systems
+   
 Now for a few examples of how to map these to Maestro's resource specifications.
 Note the `node` key is not directly used for any of these, but is still used for
 the reservation itself.  The rest of the keys serve to control the per task resources
@@ -63,7 +67,7 @@ and then the per node packing of resource sets.  Consider a few examples:
 
   .. code-block:: bash
 
-     jsrun -nrs 8 -a 1 -c 1 -g 1 -r 4 my_awesome_gpu_application
+     jsrun -nrs 8 -a 1 -c 1 -g 1 -r 4 --bind rs my_awesome_gpu_application
 
   And the corresponding maestro step that generates it
 
@@ -90,7 +94,7 @@ and then the per node packing of resource sets.  Consider a few examples:
 
   .. code-block:: bash
 
-     jsrun -nrs 44 -a 1 -c 1 -g 0 -r 44 my_awesome_mpi_cpu_application
+     jsrun -nrs 44 -a 1 -c 1 -g 0 -r 44 --bind rs my_awesome_mpi_cpu_application
 
   .. code-block:: yaml
 
@@ -114,7 +118,7 @@ and then the per node packing of resource sets.  Consider a few examples:
 
   .. code-block:: bash
 
-     jsrun -nrs 4 -a 1 -c 11 -g 0 -r 4 my_awesome_omp_mpi_cpu_application
+     jsrun -nrs 4 -a 1 -c 11 -g 0 -r 4 --bind rs my_awesome_omp_mpi_cpu_application
 
   .. code-block:: yaml
 
@@ -137,7 +141,7 @@ and then the per node packing of resource sets.  Consider a few examples:
 
   .. code-block:: bash
 
-     jsrun -nrs 8 -a 1 -c 11 -g 1 -r 4 my_awesome_all_the_threads_application
+     jsrun -nrs 8 -a 1 -c 11 -g 1 -r 4 --bind rs my_awesome_all_the_threads_application
 
   .. code-block:: yaml
 
@@ -160,7 +164,7 @@ and then the per node packing of resource sets.  Consider a few examples:
 
   .. code-block:: bash
 
-     jsrun -nrs 2 -a 1 -c 1 -g 0 -r 1 my_memory_hungry_application
+     jsrun -nrs 2 -a 1 -c 1 -g 0 -r 1 --bind rs my_memory_hungry_application
 
   .. code-block:: yaml
 

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -16,17 +16,41 @@ addition to the `procs`, `cores per task`, and `gpu` keys, there are also
 sets, with several keywords controlling these resource sets and mapping them to
 the actual machine/node allocations:
 
-* --nrs, -n:  Number of resource sets
+.. list-table:: Mapping of LSF args to Maestro step keys
 
-* --tasks_per_rs, -a: Number of MPI tasks (ranks) in a resource set
-
-* --cpu_per_rs, -c: Number of physical CPU cores in a resource set
-
-* --gpu_per_rs, -g: Number of GPU's per resource set
-
-* --bind, -b: Specifies binding of tasks within a resource set
-
-* --rs_per_host, -r: Number of resource sets per node 
+   * - LSF (jsrun)
+     - Maestro
+     - Description
+     - Default setting
+   * - -n, --nrs
+     - procs
+     - number of resource sets
+     -
+   * - -a, --tasks_per_rs
+     - tasks_per_rs
+     - Number of MPI tasks (ranks) in a resource
+     - 
+   * - -c, --cpu_per_rs
+     - cores per task
+     - Number of physical CPU cores in a resource set
+     - 
+   * - -g, --gpu_per_rs
+     - gpus
+     - Number of GPU's per resource set
+     - 
+   * - -b, --bind
+     -
+     - Controls binding of tasks in a resource set
+     - 
+   * - -B, --bind_gpus
+     -
+     - Controls binding of tasks to GPU's in a resource set
+     - 
+   * - -r, --rs_per_host
+     - rs_per_node
+     - Number of resource sets per node
+     -
+     
 
 Now for a few examples of how to map these to Maestro's resource specifications.
 Note the `node` key is not directly used for any of these, but is still used for

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -1,6 +1,54 @@
 Scheduling Studies (a.k.a. the Batch Block)
 ===========================================
 
+The batch block is an optional component of the workflow specification that enables
+job submission and management on remote clusters.  The block contains a handful of
+keys for specifying system level information that's applicable to all scheduled
+steps:
+
+.. list-table:: Batch block keys
+
+   * - Key
+     - Description
+   * - type
+     - Select scheduler adapter to use. Currently supported are ``slurm``, ``lsf``, and
+       ``flux``, ``local``.  Default is ``local``, non-scheduled job steps.
+   * - host
+     - Name of cluster being run on
+   * - queue
+     - Machine partition to schedule jobs to.  '--partition' for slurm systems, '-q' for
+       lsf systems, ...
+   * - bank
+     - Account which runs the job; this is used for computing job priority on the cluster.
+       '--account' on slurm, '-G' on lsf, ...
+   * - reservation
+     - Name of any prereserved machine partition to submit jobs to
+   * - qos
+     - Optional quality of service options (slurm only)
+   * - flux_uri
+     - Flux specific reservation functionality
+
+The information in this block is used to populate the step specific batch scripts with the appropriate
+header comment blocks (e.g. '#SBATCH --partition' for slurm).  Additional keys such as step specific
+resource requirements (number of nodes, cpus/tasks, gpus, ...) get added here when processing
+individual steps; see subsequent sections for scheduler specific details.  Note that job steps will
+run locally unless at least the ``nodes`` or ``procs`` key in the step is populated.
+
+LOCAL
+*****
+
+Stub
+
+SLURM
+*****
+
+Stub
+
+FLUX
+****
+
+Stub
+
 LSF: a Tale of Two Launchers
 ****************************
 

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -130,3 +130,26 @@ and then the per node packing of resource sets.  Consider a few examples:
              rs_per_node: 4
              tasks_per_rs: 1
              cores per task: 11
+
+
+* An mpi application that needs lots of memory per rank
+
+  .. code-block:: bash
+
+     jsrun -nrs 2 -a 1 -c 1 -g 0 -r 1 my_memory_hungry_application
+
+  .. code-block:: yaml
+
+     study:
+         - name: run-my-app
+           description: Use all the memory for single task per node
+           run:
+             cmd: |
+                 $(LAUNCHER) my_memory_hungry_application
+
+             procs: 2
+             nodes: 2
+             gpus:  0
+             rs_per_node: 1
+             tasks_per_rs: 1
+             cores per task: 1

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -41,6 +41,26 @@ and then the per node packing of resource sets.  Consider a few examples:
 
      jsrun -nrs 8 -a 1 -c 1 -g 1 -r 4 my_awesome_gpu_application
 
+  And the corresponding maestro step that generates it
+
+  .. code-block:: yaml
+
+     study:
+         - name: run-my-app
+           description: launch the best gpu application.
+           run:
+             cmd: |
+                 $(LAUNCHER) my_awesome_gpu_application
+
+             procs: 8
+             nodes: 2
+             gpus:  1
+             rs_per_node: 4
+             tasks_per_rs: 1
+             cores per task: 1
+  
+  Note that `procs` here maps more to the tasks/resource set concept in lsf/jsrun, and
+  nodes is a multiplier on `rs_per_node` which yields the `nrs` jsrun key
 
 * 1 resource set per cpu, with no gpus, and using all 44 cpus on the node
 
@@ -48,11 +68,45 @@ and then the per node packing of resource sets.  Consider a few examples:
 
      jsrun -nrs 44 -a 1 -c 1 -g 0 -r 44 my_awesome_mpi_cpu_application
 
+  .. code-block:: yaml
+
+     study:
+         - name: run-my-app
+           description: launch a pure mpi-cpu application.
+           run:
+             cmd: |
+                 $(LAUNCHER) my_awesome_mpi_cpu_application
+
+             procs: 44
+             nodes: 1
+             gpus:  0
+             rs_per_node: 44
+             tasks_per_rs: 1
+             cores per task: 1
+
+     Again, note that `procs` is a multiple of `rs_per_node`.
+  
 * Several multithreaded mpi ranks per node, with no gpus
 
   .. code-block:: bash
 
      jsrun -nrs 4 -a 1 -c 11 -g 0 -r 4 my_awesome_omp_mpi_cpu_application
+
+  .. code-block:: yaml
+
+     study:
+         - name: run-my-app
+           description: launch an application using mpi and omp
+           run:
+             cmd: |
+                 $(LAUNCHER) my_awesome_omp_mpi_cpu_application
+
+             procs: 4
+             nodes: 1
+             gpus:  0
+             rs_per_node: 4
+             tasks_per_rs: 1
+             cores per task: 11
 
 * Several multithreaded mpi ranks per node with one gpu per rank, spanning multiple
   nodes having 4 gpu's each
@@ -60,3 +114,19 @@ and then the per node packing of resource sets.  Consider a few examples:
   .. code-block:: bash
 
      jsrun -nrs 8 -a 1 -c 11 -g 1 -r 4 my_awesome_all_the_threads_application
+
+  .. code-block:: yaml
+
+     study:
+         - name: run-my-app
+           description: Use all the threads!
+           run:
+             cmd: |
+                 $(LAUNCHER) my_awesome_all_the_threads_application
+
+             procs: 8
+             nodes: 2
+             gpus:  1
+             rs_per_node: 4
+             tasks_per_rs: 1
+             cores per task: 11

--- a/docs/source/schedulers.rst
+++ b/docs/source/schedulers.rst
@@ -131,8 +131,8 @@ and then the per node packing of resource sets.  Consider a few examples:
              procs: 8
              nodes: 2
              gpus:  1
-             rs_per_node: 4
-             tasks_per_rs: 1
+             rs per node: 4
+             tasks per rs: 1
              cores per task: 1
   
   Note that `procs` here maps more to the tasks/resource set concept in lsf/jsrun, and
@@ -156,8 +156,8 @@ and then the per node packing of resource sets.  Consider a few examples:
              procs: 44
              nodes: 1
              gpus:  0
-             rs_per_node: 44
-             tasks_per_rs: 1
+             rs per node: 44
+             tasks per rs: 1
              cores per task: 1
 
      Again, note that `procs` is a multiple of `rs_per_node`.
@@ -180,8 +180,8 @@ and then the per node packing of resource sets.  Consider a few examples:
              procs: 4
              nodes: 1
              gpus:  0
-             rs_per_node: 4
-             tasks_per_rs: 1
+             rs per node: 4
+             tasks per rs: 1
              cores per task: 11
 
 * Several multithreaded mpi ranks per node with one gpu per rank, spanning multiple
@@ -203,8 +203,8 @@ and then the per node packing of resource sets.  Consider a few examples:
              procs: 8
              nodes: 2
              gpus:  1
-             rs_per_node: 4
-             tasks_per_rs: 1
+             rs per node: 4
+             tasks per rs: 1
              cores per task: 11
 
 
@@ -226,6 +226,6 @@ and then the per node packing of resource sets.  Consider a few examples:
              procs: 2
              nodes: 2
              gpus:  0
-             rs_per_node: 1
-             tasks_per_rs: 1
+             rs per node: 1
+             tasks per rs: 1
              cores per task: 1

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -106,6 +106,7 @@ class _StepRecord:
         LOGGER.info("Generating script for %s into %s", self.name, scr_dir)
         self.to_be_scheduled, self.script, self.restart_script = \
             adapter.write_script(scr_dir, self.step)
+        LOGGER.debug("STEP: %s", self.step)
         LOGGER.info("Script: %s\nRestart: %s\nScheduled?: %s",
                     self.script, self.restart_script, self.to_be_scheduled)
 

--- a/maestrowf/interfaces/script/lsfscriptadapter.py
+++ b/maestrowf/interfaces/script/lsfscriptadapter.py
@@ -189,7 +189,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
                              " where 'rs per node' = %s, 'nodes' = %s, and"
                              " 'tasks per rs' = %s",
                              procs,
-                             rs_per_node*nodes*tasks_per_rs,
+                             int(rs_per_node)*int(nodes)*int(tasks_per_rs),
                              rs_per_node,
                              nodes,
                              tasks_per_rs)
@@ -206,7 +206,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
                              " where 'rs per node' = {}, and"
                              " 'tasks per rs' = %s",
                              procs,
-                             rs_per_node*tasks_per_rs,
+                             int(rs_per_node)*int(tasks_per_rs),
                              rs_per_node,
                              tasks_per_rs)
 
@@ -242,7 +242,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
 
         # handle mappings from node/procs to tasks/rs/nodes
 
-        cpus_per_rs = kwargs.get("cores per task", 1)
+        cpus_per_rs = kwargs.get("cpus per rs", 1)
         if not cpus_per_rs:     # Initialized to "" in study step, FIX THIS
             cpus_per_rs = 1
 

--- a/maestrowf/interfaces/script/lsfscriptadapter.py
+++ b/maestrowf/interfaces/script/lsfscriptadapter.py
@@ -103,7 +103,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
         self._cmd_flags = {
             "cmd":          "jsrun",
             # "ntasks":       "--tasks_per_rs {procs} --cpu_per_rs {procs}",
-            "rs per node":  "--r",
+            "rs per node":  "-r",
             "ntasks":       "--nrs",
             # nrs must be divisible by rs_per_host -> cum num domains, not really nodes for lrun -> bsub headers this = node count...-> or nrs == rs_per_host*nodes?
             "tasks per rs": "-a",
@@ -208,8 +208,8 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
                 str(gpus)
             ]
 
-        # Optional gpu binding
-        bind_gpus = kwargs.get("bind gpus", "none")
+        # Optional gpu binding -> LSF 10.1+
+        bind_gpus = kwargs.get("bind gpus", None)
         if bind_gpus:
             args += [
                 self._cmd_flags["bind gpus"],

--- a/maestrowf/interfaces/script/lsfscriptadapter.py
+++ b/maestrowf/interfaces/script/lsfscriptadapter.py
@@ -103,12 +103,12 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
         self._cmd_flags = {
             "cmd":          "jsrun",
             # "ntasks":       "--tasks_per_rs {procs} --cpu_per_rs {procs}",
-            "rs_per_node":  "--r",
+            "rs per node":  "--r",
             "ntasks":       "--nrs",
             # nrs must be divisible by rs_per_host -> cum num domains, not really nodes for lrun -> bsub headers this = node count...-> or nrs == rs_per_host*nodes?
             "tasks per rs": "-a",
             "gpus":         "-g",
-            "cpus_per_rs":  "-c",
+            "cpus per rs":  "-c",
             "reservation":  "-J",
             "bind":         "-b",
             "bind gpus":    "-B",
@@ -189,7 +189,8 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
 
         # Processors segment
         args += [
-            self._cmd_flags["ntasks"].format(procs=procs)
+            self._cmd_flags["ntasks"],
+            procs
         ]
 
         # Binding
@@ -212,7 +213,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
         if bind_gpus:
             args += [
                 self._cmd_flags["bind gpus"],
-                str(kwargs["bind gpus"])
+                str(bind_gpus)
             ]
 
         # handle mappings from node/procs to tasks/rs/nodes

--- a/maestrowf/interfaces/script/lsfscriptadapter.py
+++ b/maestrowf/interfaces/script/lsfscriptadapter.py
@@ -163,18 +163,6 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
         
         args = [self._cmd_flags["cmd"]]
 
-        # if nodes:
-        #     _nodes = nodes
-        #     args += [
-        #         self._cmd_flags["nodes"],
-        #         str(nodes)
-        #     ]
-        # else:
-        #     _nodes = 1
-
-        # Compute the number of CPUs per node (rs)
-        # _procs = int(int(procs)/int(_nodes))
-
         # Processors segment
         args += [
             self._cmd_flags["ntasks"],

--- a/maestrowf/interfaces/script/lsfscriptadapter.py
+++ b/maestrowf/interfaces/script/lsfscriptadapter.py
@@ -69,8 +69,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
         """
         super(LSFScriptAdapter, self).__init__()
 
-        # NOTE: Host doesn't seem to matter for SLURM. sbatch assumes that the
-        # current host is where submission occurs.
+        # NOTE: Host doesn't seem to matter for LSF
         self.add_batch_parameter("host", kwargs.pop("host"))
         self.add_batch_parameter("bank", kwargs.pop("bank"))
         self.add_batch_parameter("queue", kwargs.pop("queue"))
@@ -91,21 +90,10 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
             "error": "#BSUB -e {error}",
         }
 
-        # JSRUN cmds
-        # procs maps to -r, --rs_per_host
-        #       tasks_per_rs and cpu_per_rs should be 1 by default   -> FIND USE CASE FOR > 1
-        #       gpus are per rs also (sierra = 4 per node, so 1 per rs, 4 rs per node
-        #       nrs = num tasks -> this is ~equivalent to -n on slurm in default config
-        #       -r = resource sets per host -> need this if under subscribing
-        #          r = 1 gives exclusive node use to a resource set
-        #          in general r = num gpu per host for LLNL clusters lassen/etc
-        #
         self._cmd_flags = {
             "cmd":          "jsrun",
-            # "ntasks":       "--tasks_per_rs {procs} --cpu_per_rs {procs}",
             "rs per node":  "-r",
             "ntasks":       "--nrs",
-            # nrs must be divisible by rs_per_host -> cum num domains, not really nodes for lrun -> bsub headers this = node count...-> or nrs == rs_per_host*nodes?
             "tasks per rs": "-a",
             "gpus":         "-g",
             "cpus per rs":  "-c",

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -58,6 +58,16 @@
               {"type": "integer", "minimum": 1},
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
+          "tasks_per_rs": {
+            "anyOf": [
+              {"type": "integer", "minimum": 1},
+              {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
+            ]},
+          "rs_per_node": {
+            "anyOf": [
+              {"type": "integer", "minimum": 1},
+              {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
+            ]},
           "walltime": {
             "anyOf": [
               {"type": "string", "minLength": 1},

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -68,6 +68,11 @@
               {"type": "integer", "minimum": 1},
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
+          "cpus per rs": {
+            "anyOf": [
+              {"type": "integer", "minimum": 1},
+              {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
+            ]},            
           "bind": {
             "anyOf": [
               {"type": "string", "minLength": 1},

--- a/maestrowf/specification/schemas/yamlspecification.json
+++ b/maestrowf/specification/schemas/yamlspecification.json
@@ -58,16 +58,26 @@
               {"type": "integer", "minimum": 1},
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
-          "tasks_per_rs": {
+          "tasks per rs": {
             "anyOf": [
               {"type": "integer", "minimum": 1},
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
-          "rs_per_node": {
+          "rs per node": {
             "anyOf": [
               {"type": "integer", "minimum": 1},
               {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
             ]},
+          "bind": {
+            "anyOf": [
+              {"type": "string", "minLength": 1},
+              {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
+            ]},
+          "bind gpus": {
+            "anyOf": [
+              {"type": "string", "minLength": 1},
+              {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
+            ]},            
           "walltime": {
             "anyOf": [
               {"type": "string", "minLength": 1},

--- a/maestrowf/specification/yamlspecification.py
+++ b/maestrowf/specification/yamlspecification.py
@@ -425,8 +425,8 @@ class YAMLSpecification(Specification):
                     .strip("'")
                 )
                 raise jsonschema.ValidationError(
-                    "In {0}, {1} must be of type '{2}'."
-                    .format(parent_key, path, expected_type)
+                    "In {0}, {1} must be of type '{2}', but found '{3}'."
+                    .format(parent_key, path, expected_type, type(instance[path]).__name__)
                 )
 
             elif error.validator == "required":

--- a/samples/lulesh/lulesh_sample1_unix_lsf.yaml
+++ b/samples/lulesh/lulesh_sample1_unix_lsf.yaml
@@ -1,0 +1,99 @@
+description:
+    name: lulesh_sample1_lsf
+    description: A sample LULESH study that downloads, builds, and runs mpi and openmp weak scaling modes on LSF
+
+env:
+    variables:
+        OUTPUT_PATH: ./sample_output/lulesh
+
+    labels:
+        outfile: $(SIZE.label).$(ITERATIONS.label).$(CPUS_PER_TASK.label).$(TASKS.label).log
+
+    dependencies:
+      git:
+        - name: LULESH
+          path: $(OUTPUT_PATH)
+          url: https://github.com/LLNL/LULESH.git
+
+batch:        # NOTE: UPDATE THESE FOR YOUR SYSTEM
+    type        : lsf
+    host        : lassen
+    bank        : wbronze
+    queue       : pdebug
+
+study:
+    - name: make-lulesh
+      description: Build the MPI+OpenMP enabled version of LULESH.
+      run:
+          cmd: |
+            # LLNL specific initialization of lmod setup on the allocation
+            source /etc/profile.d/z00_lmod.sh
+
+            # NOTE: ensure a compatible mpi install is available for specified compiler
+            module load gcc/8.3.1
+
+            module load cmake/3.14.5
+            
+            cd $(LULESH)
+            mkdir build
+            cd build
+            cmake -DCMAKE_BUILD_TYPE=Release -DWITH_MPI=On -D -DWITH_OMP=On -DMPI_CXX_COMPILER=`which mpicxx` ..
+            make
+          depends: []
+          nodes: 1
+          procs: 1
+          rs per node: 1
+          tasks per rs: 1
+          cpus per rs: 40
+          walltime: "10"
+
+
+    - name: run-lulesh
+      description: Run LULESH.
+      run:
+          cmd: |
+            # LLNL specific initialization of lmod setup on the allocation
+            source /etc/profile.d/z00_lmod.sh
+            
+            # Ensure consistent mpi is active (LC systems reload mpi with compiler changes)
+            module load gcc/8.3
+            
+            # Echo parallel resources for easier id in post
+            echo "NODES: $(NODES)"
+            echo "TASKS: $(TASKS)"
+            echo "CPUS_PER_TASK: $(CPUS_PER_TASK)"
+
+            # OPENMP settings
+            export OMP_NUM_THREADS=$(CPUS_PER_TASK)
+            echo "OPENMP THREADS: $OMP_NUM_THREADS"
+            
+            $(LAUNCHER) $(LULESH)/build/lulesh2.0 -s $(SIZE) -i $(ITERATIONS) -p >& $(outfile)
+          depends: [make-lulesh]
+          nodes: $(NODES)
+          procs: $(TASKS)
+          rs per node: $(TASKS)
+          cpus per rs: $(CPUS_PER_TASK)
+          exclusive   : True
+          walltime: "00:10"
+
+
+global.parameters:
+    SIZE:
+        values  : [100, 100, 200]
+        label   : SIZE.%%
+        
+    ITERATIONS:
+        values  : [100, 100, 100]
+        label   : ITER.%%
+        
+    TASKS:
+        values  : [1, 8, 1]
+        label   : TASKS.%%
+        
+    CPUS_PER_TASK:
+        values  : [1, 1, 8]
+        label   : CPT.%%
+        
+    NODES:
+        values  : [1, 1, 1]
+        label   : NODES.%%

--- a/tests/interfaces/script/test_lsfscriptadapter.py
+++ b/tests/interfaces/script/test_lsfscriptadapter.py
@@ -1,0 +1,64 @@
+###############################################################################
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory
+# Written by Francesco Di Natale, dinatale3@llnl.gov.
+#
+# LLNL-CODE-734340
+# All rights reserved.
+# This file is part of MaestroWF, Version: 1.0.0.
+#
+# For details, see https://github.com/LLNL/maestrowf.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+###############################################################################
+"""
+This module is intended to test maestrowf.interfaces.script.slurmscriptadapter
+module. It is setup to use nose or pytest to do that testing.
+
+This was created to verify existing functionality of the ScriptAdapterFactory
+as it was converted to dynamically load all ScriptAdapters using a namespace
+plugin methodology.
+"""
+from maestrowf.interfaces.script.lsfscriptadapter import LSFScriptAdapter
+from maestrowf.interfaces import ScriptAdapterFactory
+
+
+def test_lsf_adapter():
+    """
+    Tests to verify that LSFScriptAdapter has the key property set to 'lsf'
+    this is validate that existing specifications do not break.
+    :return:
+    """
+    assert(LSFScriptAdapter.key == 'lsf')
+
+
+def test_lsf_adapter_in_factory():
+    """
+    Testing to makes sure that the LSFScriptAdapter has been registered
+    correctly in the ScriptAdapterFactory.
+    :return:
+    """
+    saf = ScriptAdapterFactory
+    # Make sure LSFScriptAdapter is in the facotries object
+    assert(saf.factories[LSFScriptAdapter.key] == LSFScriptAdapter)
+    # Make sure the SlurmScriptAdapter key is in the valid adapters
+    assert(LSFScriptAdapter.key in ScriptAdapterFactory.get_valid_adapters())
+    # Make sure that get_adapter returns the SlurmScriptAdapter when asking
+    # for it by key
+    assert(ScriptAdapterFactory.get_adapter(LSFScriptAdapter.key) ==
+           LSFScriptAdapter)


### PR DESCRIPTION
Enables more complete specification of jsrun launcher

Adds new step keys to deal with unique resource specification differences that procs/nodes don't fully map to

Overloads cores per task with lsf's  cpus_per_rs to remain backwards compatible with existing yaml specification