### PR TITLE
Print usage when no args provided

### DIFF
--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -369,6 +369,9 @@ def setup_argparser():
         description="The Maestro Workflow Conductor for specifying, launching"
         ", and managing general workflows.",
         formatter_class=RawTextHelpFormatter)
+    # This call applies a default function to the main parser as described
+    # here: https://stackoverflow.com/a/61680800
+    parser.set_defaults(func=lambda args: parser.print_help())
     subparsers = parser.add_subparsers(dest='subparser')
 
     # subparser for a cancel subcommand


### PR DESCRIPTION
Hi,

Running `maestro` for the first time ever today from the `develop` branch. I first tried `maestro` without anything else, but it resulted in a traceback.

```bash
(venv) kinow@ranma:~/Development/python/workspace/maestrowf$ maestro 
Traceback (most recent call last):
  File "/home/kinow/Development/python/workspace/maestrowf/venv/bin/maestro", line 8, in <module>
    sys.exit(main())
  File "/home/kinow/Development/python/workspace/maestrowf/maestrowf/maestro.py", line 495, in main
    if not hastattr(args, 'func'):
NameError: name 'hastattr' is not defined
```
I think it would be best to print the program usage instead? So if users are not aware, or not sure, which subcommand/subparser to trigger, they can read the usage and decide then.

Thanks for maestro! :wave: 
-Bruno

EDIT: closes #188 (hadn't seen the issue, sorry)