### PR TITLE
Bugfix/slurm job checking

### DIFF
--- a/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
+++ b/maestrowf/abstracts/interfaces/schedulerscriptadapter.py
@@ -230,7 +230,7 @@ class SchedulerScriptAdapter(ScriptAdapter):
                 LOGGER.error(msg)
                 raise ValueError(msg)
 
-            if total_nodes > nodes:
+            if nodes and total_nodes > nodes:
                 msg = "Total nodes ({}) requested exceeds the " \
                       "maximum requested ({})".format(total_nodes, nodes)
                 LOGGER.error(msg)

--- a/samples/hello_world/hello_bye_parameterized_slurm.yaml
+++ b/samples/hello_world/hello_bye_parameterized_slurm.yaml
@@ -1,0 +1,39 @@
+description:
+    name: hello_bye_world
+    description: A study that says hello and bye to multiple people.
+
+batch:
+    type        : slurm
+    host        : rzgenie
+    bank        : wbronze
+    queue       : pdebug
+
+env:
+    variables:
+        OUTPUT_PATH: ./sample_output/hello_world
+    labels:
+        OUT_FORMAT: $(GREETING)_$(NAME).txt
+
+study:
+    - name: hello_world
+      description: Say hello to someone!
+      run:
+          cmd: |
+            $(LAUNCHER) echo "$(GREETING), $(NAME)!" > $(OUT_FORMAT)
+          procs: 1
+          
+    - name: bye_world
+      description: Say bye to someone!
+      run:
+          cmd: |
+            $(LAUNCHER)[1p] echo "Bye, World!" > bye.txt
+          procs: 1
+          depends: [hello_world]
+
+global.parameters:
+    NAME:
+        values: [Pam, Jim, Michael, Dwight]
+        label: NAME.%%
+    GREETING:
+        values: [Hello, Ciao, Hey, Hi]
+        label: GREETING.%%


### PR DESCRIPTION
Fixes issue with job checking on slurm systems that can result in steps never being marked finished.  The squeue command appears to flush finished/cancelled/killed jobs from the queue before maestro can check on the jobs and update their status.  Have yet to reproduce this in maestro studies, but can reproduces with manual job submissions and using ctrl-c to kill them and watching the squeue iterate output drop the job almost immediately.  This fix replaces squeue with sacct which preserves the job info for much longer.