### PR TITLE
no scheduled scripts missig #! on lsf

### DIFF
--- a/maestrowf/interfaces/script/lsfscriptadapter.py
+++ b/maestrowf/interfaces/script/lsfscriptadapter.py
@@ -468,7 +468,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
             if to_be_scheduled:
                 script.write(self.get_header(step))
             else:
-                script.write(self._exec)
+                script.write("#!{}".format(self._exec))
 
             cmd = "\n\n{}\n".format(cmd)
             script.write(cmd)
@@ -481,7 +481,7 @@ class LSFScriptAdapter(SchedulerScriptAdapter):
                 if to_be_scheduled:
                     script.write(self.get_header(step))
                 else:
-                    script.write(self._exec)
+                    script.write("#!{}".format(self._exec))
 
                 cmd = "\n\n{}\n".format(restart)
                 script.write(cmd)


### PR DESCRIPTION
fixes a bug where scripts on lsf would start w/o #! in front of the shell