### PR TITLE
Pin mermaid to 9.4 due to api breaking change in 10.x

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: '3.10'
   jobs:
     post_install:
-      - pip install poetry>=1.2
+      - pip install "poetry>=1.4,<1.5"
       - poetry config virtualenvs.create false
       - poetry install
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ plugins:
           # theme: |
           #   ^(JSON.parse(__md_get("__palette").index == 1)) ? 'dark' : 'light'
 extra_javascript:
-    - https://unpkg.com/mermaid/dist/mermaid.min.js
+    - https://unpkg.com/mermaid@9.4.3/dist/mermaid.min.js
 
 extra_css:
   - custom.css


### PR DESCRIPTION
Pins mermaid package to last pre 10.x version to restore diagrams broken by 10.x api change