### PR TITLE
Fix flux job cancellation

### DIFF
--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -872,9 +872,9 @@ class ExecutionGraph(DAG, PickleInterface):
                     "Unfulfilled dependencies: %s",
                     self._dependencies[key])
 
-                s_completed = filter(
+                s_completed = list(filter(
                     lambda x: x in self.completed_steps,
-                    self._dependencies[key])
+                    self._dependencies[key]))
                 self._dependencies[key] = \
                     self._dependencies[key] - set(s_completed)
                 LOGGER.debug(

--- a/maestrowf/interfaces/script/_flux/flux0_26_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_26_0.py
@@ -232,9 +232,15 @@ class FluxInterface_0260(FluxInterface):
             "\n".join(str(j) for j in joblist),
         )
 
+        # NOTE: cannot pickle JobID instances, so must store as strings and
+        # reconstruct for use
+        jobs_rpc = flux.job.list.JobList(
+            cls.flux_handle,
+            ids=[flux.job.JobID(jid) for jid in joblist])
+
         cancel_code = CancelCode.OK
         cancel_rcode = 0
-        for job in joblist:
+        for job in jobs_rpc:
             try:
                 LOGGER.debug("Cancelling Job %s...", job)
                 flux.job.cancel(cls.flux_handle, int(job))

--- a/maestrowf/interfaces/script/_flux/flux0_49_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_49_0.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 class FluxInterface_0490(FluxInterface):
-    # This utility class is for Flux 0.26.0
+    # This utility class is for Flux 0.49.0
     key = "0.49.0"
 
     flux_handle = None
@@ -242,9 +242,15 @@ class FluxInterface_0490(FluxInterface):
             "\n".join(str(j) for j in joblist),
         )
 
+        # NOTE: cannot pickle JobID instances, so must store as strings and
+        # reconstruct for use
+        jobs_rpc = flux.job.list.JobList(
+            cls.flux_handle,
+            ids=[flux.job.JobID(jid) for jid in joblist])
+
         cancel_code = CancelCode.OK
         cancel_rcode = 0
-        for job in joblist:
+        for job in jobs_rpc:
             try:
                 LOGGER.debug("Cancelling Job %s...", job)
                 flux.job.cancel(cls.flux_handle, int(job))

--- a/maestrowf/interfaces/script/_flux/flux0_49_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_49_0.py
@@ -250,12 +250,12 @@ class FluxInterface_0490(FluxInterface):
 
         cancel_code = CancelCode.OK
         cancel_rcode = 0
-        for job in jobs_rpc:
+        for job in jobs_rpc.jobs():
             try:
-                LOGGER.debug("Cancelling Job %s...", job)
-                flux.job.cancel(cls.flux_handle, int(job))
+                LOGGER.debug("Cancelling Job %s...", str(job.id.f58))
+                flux.job.cancel(cls.flux_handle, int(job.id))
             except Exception as exception:
-                LOGGER.error(str(exception))
+                LOGGER.error("Job %s: %s", str(job.id.f58), str(exception))
                 cancel_code = CancelCode.ERROR
                 cancel_rcode = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "maestrowf"
-version = "1.1.10dev4"
+version = "1.1.10dev5"
 description = "A tool to easily orchestrate general computational workflows both locally and on supercomputers."
 license = "MIT License"
 classifiers = [


### PR DESCRIPTION
Update 0.49 and 0.26 adapters cancellation to deal with recent update to submit that converts from flux JobID to native types.

Update general cancellation behaviors:
- Check for in progress steps before declaring cancelled successfully to delay until actual final states can be serialized
- Update cancel logic to mirror failure logic: mark all steps downstream of a cancelled step to also be cancelled