### PR TITLE
slurm adapter robustness

### DIFF
--- a/maestrowf/interfaces/script/slurmscriptadapter.py
+++ b/maestrowf/interfaces/script/slurmscriptadapter.py
@@ -257,9 +257,11 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
         # squeue options:
         # -u = username to search queues for.
         # -t = list of job states to search for. 'all' for all states.
-        # -f = custom format options to guard against user customizations
+        # -o = custom format options to guard against user customizations
 
         squeue_fmt = "%.18i %.8j %.8u %.2t"
+        # see https://slurm.schedmd.com/squeue.html#OPT_format for explanation
+        # NOTE: look into --json/--yaml output options
         # The squeue command output is split with the following indices
         # used for specific information:
         # 0 - Job Identifier
@@ -342,7 +344,6 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
         .. note:: While more robust than squeue, testing reveals this
                   cmd is not always available to users
         """
-        cmd = "sacct -u $USER --jobs={jids} --format={cols}"
         # Note: can add similar columns as squeue defaults to if needed
         # sacct -u $USER --jobs=jobid1,jobid2,jobid3 \
         #    --format=jobid,partition,jobname,user,state,time,nnodes,\
@@ -353,6 +354,8 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
 
         sacct_fmt = ["jobid", "jobname", "state", "exitcode"]
         # columns exposed in sacct
+        # see https://slurm.schedmd.com/sacct.html#OPT_format for explanation
+        # NOTE: look into --parsable2, --json, --yaml options
         # 1 - JobID (includes entries for job steps too: jobid.step)
         # 2 - JobName (includes job step names)
         # 3 - State
@@ -363,7 +366,7 @@ class SlurmScriptAdapter(SchedulerScriptAdapter):
         state_index = 2
         jobid_index = 0
 
-        cmd = cmd.format(jids=','.join(joblist), cols=','.join(sacct_fmt))
+        cmd = f"sacct -u $USER --jobs={','.join(joblist)} --format={','.join(sacct_fmt)}"
         LOGGER.debug("Using sacct cmd: %s", cmd)
         p = start_process(cmd)
         output, err = p.communicate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "maestrowf"
-version = "1.1.10dev5"
+version = "1.1.10dev6"
 description = "A tool to easily orchestrate general computational workflows both locally and on supercomputers."
 license = "MIT License"
 classifiers = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ markers =
     sched_flux: tests that exercise flux scheduler and require flux bindings
     sched_slurm: tests that exercise slurm scheduler
     sched_lsf: tests that exercise lsf scheduler
+    integration: integration tests that exercise full execution of sample workflows

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,14 @@ def check_slurm():
     """
     Checks if there is a slurm instance to schedule to. NOT IMPLEMENTED YET.
     """
-    slurm_ver_output_lines = check_output(['sinfo','-V'], encoding='utf8')
+    slurm_info_func = 'sinfo'
+    try:
+        slurm_ver_output_lines = check_output([slurm_info_func,'-V'], encoding='utf8')
+    except FileNotFoundError as fnfe:
+        if fnfe.filename == slurm_info_func:
+            return False
+
+        raise
 
     slurm_ver_parts = slurm_ver_output_lines.split('\n')[0].split()
     version = parse_version(slurm_ver_parts[1])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 from collections import defaultdict
 import os
+from subprocess import check_output
 
 import pytest
 
+from maestrowf.utils import parse_version
 
 SCHEDULERS = set(('sched_lsf', 'sched_slurm', 'sched_flux'))
 SCHED_CHECKS = defaultdict(lambda: False)
@@ -22,6 +24,14 @@ def check_slurm():
     """
     Checks if there is a slurm instance to schedule to. NOT IMPLEMENTED YET.
     """
+    slurm_ver_output_lines = check_output(['sinfo','-V'], encoding='utf8')
+
+    slurm_ver_parts = slurm_ver_output_lines.split('\n')[0].split()
+    version = parse_version(slurm_ver_parts[1])
+
+    if slurm_ver_parts[0].lower() == 'slurm' and version:
+        return True
+
     return False
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture
+def check_study_success():
+    """Fixture to provide log based study completion test"""
+    def _check_study_success(log_lines, study_name):
+        """Helper to check log file for successful completion entry"""
+        completed_successfully = False
+        success_str = f"INFO] '{study_name}' is complete. Returning."
+
+        for line in log_lines:
+            if success_str in line:
+                completed_successfully = True
+
+        return completed_successfully
+
+    return _check_study_success

--- a/tests/integration/test_flux.py
+++ b/tests/integration/test_flux.py
@@ -19,6 +19,7 @@ pytestmark = pytest.mark.sched_flux
     ]
 )
 def test_hello_world_flux(samples_spec_path,
+                          check_study_success,
                           spec_name,
                           tmp_dir,
                           flux_adaptor_version):
@@ -37,7 +38,6 @@ def test_hello_world_flux(samples_spec_path,
 
     spec = YAMLSpecification.load_specification(spec_path)
     study_name = spec.name
-    success_str = f"INFO] '{study_name}' is complete. Returning."
 
     # Run in foreground to enable easier checking of successful studies
     spec_results = run(["maestro",
@@ -55,10 +55,10 @@ def test_hello_world_flux(samples_spec_path,
         testlog.write(spec_results.stdout)
         testlog.write(spec_results.stderr)
 
-    completed_successfully = False
-    for line in spec_results.stderr.split('\n'):
-        if success_str in line:
-            completed_successfully = True
+    completed_successfully = check_study_success(
+        spec_results.stderr.split('\n'),
+        study_name
+    )
 
     assert completed_successfully
     assert spec_results.returncode == 0

--- a/tests/integration/test_flux.py
+++ b/tests/integration/test_flux.py
@@ -9,7 +9,8 @@ from maestrowf.specification.yamlspecification import YAMLSpecification
 
 
 # Tag every test in this file as requiring flux
-pytestmark = pytest.mark.sched_flux
+pytestmark = [pytest.mark.sched_flux,
+              pytest.mark.integration,]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_slurm.py
+++ b/tests/integration/test_slurm.py
@@ -1,0 +1,68 @@
+import os
+from shutil import rmtree
+from subprocess import run
+# import tempfile
+
+import pytest
+
+from maestrowf.specification.yamlspecification import YAMLSpecification
+
+
+# Tag every test in this file as requiring flux
+pytestmark = [pytest.mark.sched_slurm,
+              pytest.mark.integration,]
+
+
+@pytest.mark.parametrize(
+    "spec_name, tmp_dir",
+    [
+        ("hello_bye_parameterized_slurm.yaml", "HELLO_BYE_SLURM"),
+    ]
+)
+def test_hello_world_slurm(samples_spec_path,
+                           check_study_success,
+                           spec_name,
+                           tmp_dir):
+    """
+    Run integration tests using the slurm scheduler.
+    """
+    spec_path = samples_spec_path(spec_name)
+    # TEMP dir run tests always trigger failure when running on flux machine?
+    # tmp_outdir = tempfile.mkdtemp()
+
+    tmp_outdir = os.path.abspath(os.path.join(os.getcwd(), tmp_dir))
+
+    # Clean up detritus from failed tests
+    if os.path.exists(tmp_outdir):
+        rmtree(tmp_outdir, ignore_errors=True)  # recursively delete workspace
+
+    spec = YAMLSpecification.load_specification(spec_path)
+    study_name = spec.name
+
+    # Run in foreground to enable easier checking of successful studies
+    spec_results = run(["maestro",
+                        "run",
+                        "-s 1",
+                        "-fg",
+                        "-o",
+                        tmp_outdir,
+                        "--autoyes",
+                        spec_path],
+                       capture_output=True,
+                       encoding="utf-8")
+
+    with open(os.path.join(tmp_dir, 'logs', study_name + '_fg.log'), 'w') as testlog:
+        testlog.write(spec_results.stdout)
+        testlog.write(spec_results.stderr)
+
+    completed_successfully = check_study_success(
+        spec_results.stderr.split('\n'),
+        study_name
+    )
+
+    assert completed_successfully
+    assert spec_results.returncode == 0
+
+    # Cleanup if successful
+    if os.path.exists(tmp_outdir):
+        rmtree(tmp_outdir, ignore_errors=True)  # recursively delete workspace

--- a/tests/interfaces/script/test_slurmscriptadapter.py
+++ b/tests/interfaces/script/test_slurmscriptadapter.py
@@ -34,9 +34,19 @@ This was created to verify existing functionality of the ScriptAdapterFactory
 as it was converted to dynamically load all ScriptAdapters using a namespace
 plugin methodology.
 """
+import logging
+import os
+import re
+import time
+
+from maestrowf.abstracts.enums import State, JobStatusCode
 from maestrowf.interfaces.script.slurmscriptadapter import SlurmScriptAdapter
 from maestrowf.interfaces import ScriptAdapterFactory
+from maestrowf.utils import start_process
 
+import pytest
+
+TESTLOGGER = logging.getLogger(__name__)
 
 def test_slurm_adapter():
     """
@@ -62,3 +72,93 @@ def test_slurm_adapter_in_factory():
     # for it by key
     assert(ScriptAdapterFactory.get_adapter(SlurmScriptAdapter.key) ==
            SlurmScriptAdapter)
+
+
+# Slurm fixtures for checking scheduler connectivity
+@pytest.mark.sched_slurm
+@pytest.fixture()
+def slurm_test_jobs():
+    """Spin up a couple sample jobs to test slurm connectivity"""
+
+    # Archive the squeue/sacct formats so we can change them from defaults to verify
+    # that user customizations don't break the adapter
+    orig_sacct_fmt = os.getenv('SACCT_FORMAT')
+    TESTLOGGER.warn("Original SACCT_FORMAT: %s", orig_sacct_fmt)
+    orig_squeue_fmt = os.getenv('SQUEUE_FORMAT')
+    TESTLOGGER.warn("Original SQUEUE_FORMAT: %s", orig_squeue_fmt)
+
+    # Test out a users custom fmt here which had broken things previously (squeue)
+    new_sacct_fmt = 'jobid,jobname,account,partition,nnodes,state,start,elapsed,timelimit,priority'
+    new_squeue_fmt = '%.7i %.8u %.8a %.9P %.5D %.2t %.19S %.8M %.10l %10Q'
+    
+    os.environ['SACCT_FORMAT'] = new_sacct_fmt
+    os.environ['SQUEUE_FORMAT'] = new_squeue_fmt
+    TESTLOGGER.warn("Override SACCT_FORMAT: %s", os.environ['SACCT_FORMAT'])
+    TESTLOGGER.warn("Override SQUEUE_FORMAT: %s", os.environ['SQUEUE_FORMAT'])
+    
+    jobids = []
+    test_cmds = ["echo 'Test Job {}';srun -n1 sleep 60".format(idx) for idx in range(1)]
+    for cmd in test_cmds:
+        p = start_process(['sbatch', f'--wrap={cmd}', '-n', '1'], #.format(test_cmd=cmd)],
+                          cwd=os.getcwd(),
+                          env=os.environ)
+        output, err = p.communicate()
+        retcode = p.wait()
+
+        if retcode == 0:
+            jobids.append(re.search('[0-9]+', output).group(0))
+        else:
+            print(f'Error submitting job. retcode: {retcode}, output: {output}, err: {err}')
+
+    yield jobids
+
+    # Cleanup   (NOTE: want to also try cancelling jobs here or just let them run out?)
+    if orig_sacct_fmt:
+        os.environ['SACCT_FORMAT'] = orig_sacct_fmt
+    else:
+        os.environ.pop('SACCT_FORMAT')
+
+    if orig_squeue_fmt:
+        os.environ['SQUEUE_FORMAT'] = orig_squeue_fmt
+    else:
+        os.environ.pop('SQUEUE_FORMAT')
+
+    TESTLOGGER.warn("Reverted SACCT_FORMAT: %s", os.getenv('SACCT_FORMAT'))
+    TESTLOGGER.warn("Reverted SQUEUE_FORMAT: %s", os.getenv('SQUEUE_FORMAT'))
+
+@pytest.mark.sched_slurm
+def test_slurm_check(slurm_test_jobs, caplog):
+    jobids = slurm_test_jobs
+    caplog.set_level(logging.DEBUG)
+
+    TESTLOGGER.warn("SACCT_FORMAT = %s", os.environ['SACCT_FORMAT'])
+    TESTLOGGER.warn("SQUEUE_FORMAT = %s", os.environ['SQUEUE_FORMAT'])
+
+    slurm_adapter = ScriptAdapterFactory.get_adapter(SlurmScriptAdapter.key)(
+        host='dummy_host',
+        bank='dummy_bank',
+        queue='dummy_queue',
+        nodes=''
+    )
+
+    # NOTE: sacct output is often blank with shorter sleep times. Maybe smarter
+    #       handling with auto retries if sacct empty but squeue is fine?
+    time.sleep(5)
+    status_dict = {jobid: None for jobid in jobids}
+    job_status_sacct = slurm_adapter._check_jobs_sacct(jobids, status_dict)
+    status_dict = {jobid: None for jobid in jobids}
+    job_status_squeue = slurm_adapter._check_jobs_squeue(jobids, status_dict)
+
+
+    failed_states = [State.FAILED, State.HWFAILURE]
+
+    TESTLOGGER.warn("Testing squeue statuses: %s", job_status_squeue[1])
+    assert job_status_squeue[1]
+    for jobid, jobstate in job_status_squeue[1].items():
+        assert jobstate not in failed_states and jobstate in State
+
+    TESTLOGGER.warn("Testing sacct statuses: %s", job_status_sacct[1])
+    assert job_status_sacct[1]  # Make sure it's not empty
+    for jobid, jobstate in job_status_sacct[1].items():
+        assert jobstate         # Catch none with better err msg
+        assert jobstate not in failed_states and jobstate in State


### PR DESCRIPTION
Slurm adapter bugfixes
* Adds prescribed column lists to both squeue and sacct to avoid parsing issues due to optional user environment variables 'SQUEUE_FORMAT' and 'SACCT_FORMAT'.
* Reduces some unneeded columns in sacct to make it more robust (not all machines have accounts, which broke the parsing)

Test additions
* Enabled detection of slurm scheduler for live test subset (sched_slurm marker) with auto disablement of marked tests to remain quiet in github ci
* Unit tests added for slurm adapter
  * check use of squeue and sacct job status checking options in presence of custom squeue/sacct format env vars
  * check functionality of job cancellation
* Slurm 'hello world' integration test