### PR TITLE
Update study configuration during execution

### DIFF
--- a/docs/Maestro/cli.md
+++ b/docs/Maestro/cli.md
@@ -38,6 +38,7 @@ maestro [OPTIONS] COMMAND [ARGS]...
 - [*cancel*](#cancel): Cancel all running jobs.
 - [*run*](#run): Launch a study based on a specification
 - [*status*](#status): Check the status of a running study.
+- [*update*](#update): Update a running study
 
 ### **cancel**
 
@@ -105,6 +106,40 @@ maestro status [OPTIONS] DIRECTORY [DIRECTORY ...]
 | `--disable-theme` | boolean | Turn off styling for the status layout. See [Status Theme](monitoring.md#status-theme) for more information on this option. | `False` |
 | `--disable-pager` | boolean | Turn off the pager for the status display. See [Status Pager](monitoring.md#status-pager) for more information on this option. | `False` |
 
+
+### **update**
+
+Update the config of a running study.  Currently limited to three settings: throttle, restart limit (rlimit), and sleep.  Explicitly set each argument via keyword args, interactively set for each study, or a mix of the two. Supports updating multiple studies at once.
+
+!!! note
+
+    This command will drop a hidden file in your study workspace '.study.update.lock' which conductor reads asynchronously and removes upon successful reading.  Applying this command to a finished study will currently leave this file in your workspace.  Similarly, this file will also not be cleaned up if conductor crashes before reading.
+
+**Usage:**
+
+``` console
+maestro update [-h] [--rlimit RLIMIT] [--sleep SLEEP] [--throttle THROTTLE] DIRECTORY [DIRECTORY ...]
+```
+
+**Options:**
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `-h`, `--help` | boolean | Show this help message and exit. | `False` |
+| `--rlimit` | integer | Update maximum number of restarts when steps specify a restart command (0 denotes no limit) | None |
+| `--sleep` | integer  | Update the time (in seconds) that the manager (conductor) will wait between job status checks. | None |
+| `--throttle` | integer  | Update the maximum number of inflight jobs allowed to execute simultaneously (0 denotes no throttling). | None |
+
+
+**Examples:**
+
+``` console title="Update 1 study"
+maestro update --rlimit 4 /path/to/my/timestamped/study/workspace/
+```
+
+``` console title="Update 2 studies"
+maestro update --rlimit 4 --rlimit 2 /path/to/my/timestamped/study/workspace_1/ /path/to/my/timestamped/study/workspace_2/
+```
 
 ## **conductor**
 

--- a/docs/Maestro/cli.md
+++ b/docs/Maestro/cli.md
@@ -161,27 +161,31 @@ maestro update --rlimit 4 --rlimit 2 /path/to/my/timestamped/study/workspace_1/ 
 <!-- termynal -->
 ```
 $ maestro update ./sample_output/hello_world_restart/hello_bye_world_20241119-173122
-Study in '/path/to/sample_output/hello_world_restart/hello_bye_world_20241119-173122' to be updated.
-Choose study config to update, or quit
-Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122
-[rlimit/throttle/sleep/quit]
+Updating study at '/path/to/sample_output/hello_world_restart/hello_bye_world_20241119-173122'
+Choose study config to update, or done/quit to finish/abort
+[rlimit/throttle/sleep/done/quit]
 > rlimit
-update_menu_choice='rlimit'
-Updating restart limit
-Enter new restart limit
+Enter new restart limit [Integer, 0 = unlimited]
 > 4
 Choose study config to update, or quit
-Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122 
- [rlimit/throttle/sleep/quit]
+ [rlimit/throttle/sleep/done/quit]
 > sleep
-update_menu_choice='sleep'
-Enter new sleep duration for Conductor
+Enter new sleep duration for Conductor [Integer, seconds]
 > 30
 Choose study config to update, or quit
-Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122
- [rlimit/throttle/sleep/quit]
+ [rlimit/throttle/sleep/done/quit]
 > quit
-update_menu_choice='quit'
+Discarding updates to 'sample_output/hello_world_restart/hello_bye_world_20241119-173122/'
+$ maestro update ./sample_output/hello_world_restart/hello_bye_world_20241119-173122
+Updating study at '/path/to/sample_output/hello_world_restart/hello_bye_world_20241119-173122'
+Choose study config to update, or done/quit to finish/abort
+[rlimit/throttle/sleep/done/quit]
+> rlimit
+Enter new restart limit [Integer, 0 = unlimited]
+> 4
+Choose study config to update, or quit
+ [rlimit/throttle/sleep/done/quit]
+> done
 Writing updated study config to 'sample_output/hello_world_restart/hello_bye_world_20241119-173122/.study.update.lock'
 ```
 

--- a/docs/Maestro/cli.md
+++ b/docs/Maestro/cli.md
@@ -131,30 +131,56 @@ maestro update [-h] [--rlimit RLIMIT] [--sleep SLEEP] [--throttle THROTTLE] DIRE
 | `--throttle` | integer  | Update the maximum number of inflight jobs allowed to execute simultaneously (0 denotes no throttling). | None |
 
 
-**Examples:**
+#### **Examples**
 
-``` console title="Update 1 study"
+**Update a single study configuration value for a single study:**
+
+``` console title="Change single config value for a single study"
 maestro update --rlimit 4 /path/to/my/timestamped/study/workspace/
 ```
 
-``` console title="Update 2 studies"
+**Update multiple study configuration values for a single study:**
+
+``` console title="Change multiple config values for a single study"
+maestro update --rlimit 4 --throttle 2 /path/to/my/timestamped/study/workspace/
+```
+**Update single study configuration value for multiple studies:**
+
+``` console title="Single config value, two studies"
 maestro update --rlimit 4 --rlimit 2 /path/to/my/timestamped/study/workspace_1/ /path/to/my/timestamped/study/workspace_2/
 ```
 
-``` console title="Interactively update 1 study"
-$ maestro update samples/hello_world/sample_output/hello_world_restart/hello_bye_world_20241119-173122
-Study in '/path/to/maestro_repo/samples/hello_world/sample_output/hello_world_restart/hello_bye_world_20241119-173122' to be updated.
+**Update multiple study configuration values for multiple studies:**
+
+``` console title="Multiple config values, two studies"
+maestro update --rlimit 4 --rlimit 2 /path/to/my/timestamped/study/workspace_1/ /path/to/my/timestamped/study/workspace_2/
+```
+
+**Interactively update study configuration for one study:**
+
+<!-- termynal -->
+```
+$ maestro update ./sample_output/hello_world_restart/hello_bye_world_20241119-173122
+Study in '/path/to/sample_output/hello_world_restart/hello_bye_world_20241119-173122' to be updated.
 Choose study config to update, or quit
-Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122 [rlimit/throttle/sleep/quit]: rlimit
+Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122
+[rlimit/throttle/sleep/quit]
+> rlimit
 update_menu_choice='rlimit'
 Updating restart limit
-Enter new restart limit: 4
+Enter new restart limit
+> 4
 Choose study config to update, or quit
-Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122 [rlimit/throttle/sleep/quit]: sleep
+Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122 
+ [rlimit/throttle/sleep/quit]
+> sleep
 update_menu_choice='sleep'
-Enter new sleep duration for Conductor: 30
+Enter new sleep duration for Conductor
+> 30
 Choose study config to update, or quit
-Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122 [rlimit/throttle/sleep/quit]: quit
+Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122
+ [rlimit/throttle/sleep/quit]
+> quit
 update_menu_choice='quit'
 Writing updated study config to 'sample_output/hello_world_restart/hello_bye_world_20241119-173122/.study.update.lock'
 ```

--- a/docs/Maestro/cli.md
+++ b/docs/Maestro/cli.md
@@ -141,6 +141,24 @@ maestro update --rlimit 4 /path/to/my/timestamped/study/workspace/
 maestro update --rlimit 4 --rlimit 2 /path/to/my/timestamped/study/workspace_1/ /path/to/my/timestamped/study/workspace_2/
 ```
 
+``` console title="Interactively update 1 study"
+$ maestro update samples/hello_world/sample_output/hello_world_restart/hello_bye_world_20241119-173122
+Study in '/path/to/maestro_repo/samples/hello_world/sample_output/hello_world_restart/hello_bye_world_20241119-173122' to be updated.
+Choose study config to update, or quit
+Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122 [rlimit/throttle/sleep/quit]: rlimit
+update_menu_choice='rlimit'
+Updating restart limit
+Enter new restart limit: 4
+Choose study config to update, or quit
+Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122 [rlimit/throttle/sleep/quit]: sleep
+update_menu_choice='sleep'
+Enter new sleep duration for Conductor: 30
+Choose study config to update, or quit
+Study: sample_output/hello_world_restart/hello_bye_world_20241119-173122 [rlimit/throttle/sleep/quit]: quit
+update_menu_choice='quit'
+Writing updated study config to 'sample_output/hello_world_restart/hello_bye_world_20241119-173122/.study.update.lock'
+```
+
 ## **conductor**
 
 A application for checking and managing and ExecutionDAG within an executing study.

--- a/maestrowf/conductor.py
+++ b/maestrowf/conductor.py
@@ -302,7 +302,7 @@ class Conductor:
         study_update_path = make_safe_path(output_path, cls._study_update)
         # NOTE: should we timestamp these, or append separate timestamped docs
         # to the yaml?
-        print(f"Writing updated config to %s", study_update_path)
+        print(f"Writing updated study config to '{study_update_path}'")
         with open(study_update_path, 'wb') as study_update:
             study_update.write(yaml.dump(updated_config).encode("utf-8"))
 

--- a/maestrowf/conductor.py
+++ b/maestrowf/conductor.py
@@ -406,18 +406,18 @@ class Conductor:
             if os.path.exists(study_update_path):
                 updated_study_config = self.load_updated_study_exec(self.output_path)
 
-                if "throttle" in updated_study_config:
+                if "throttle" in updated_study_config and updated_study_config["throttle"]:
                     LOGGER.info("Updating throttle from %d to %d",
                                 dag._submission_throttle,  # NOTE: make a property?
                                 updated_study_config["throttle"])
                     dag.update_throttle(updated_study_config["throttle"])
 
-                if "rlimit" in updated_study_config:
+                if "rlimit" in updated_study_config and updated_study_config["rlimit"]:
                     LOGGER.info("Updating restart limit to %d",
                                 updated_study_config["rlimit"])
                     dag.update_rlimit(updated_study_config["rlimit"])
 
-                if "sleep" in updated_study_config:
+                if "sleep" in updated_study_config and updated_study_config["sleep"]:
                     LOGGER.info("Updating conductor sleep time from %s to %s",
                                 str(self.sleep_time),
                                 str(updated_study_config["sleep"]))

--- a/maestrowf/conductor.py
+++ b/maestrowf/conductor.py
@@ -34,6 +34,7 @@ import glob
 import inspect
 import logging
 import os
+import shutil
 import sys
 from time import sleep
 import dill
@@ -140,6 +141,7 @@ class Conductor:
 
     _pkl_extension = ".study.pkl"
     _cancel_lock = ".cancel.lock"
+    _study_update = ".study.update.lock"
     _batch_info = "batch.info"
 
     def __init__(self, study):
@@ -289,6 +291,60 @@ class Conductor:
         with open(lock_path, 'a'):
             os.utime(lock_path, None)
 
+    @classmethod
+    def update_study_exec(cls, output_path, updated_config):
+        """
+        Mark the study rooted at 'out_path'.
+
+        :param out_path: A string containing the patht to a study root.
+        :returns: A dictionary containing the status of the study.
+        """
+        study_update_path = make_safe_path(output_path, cls._study_update)
+        # NOTE: should we timestamp these, or append separate timestamped docs
+        # to the yaml?
+        print(f"Writing updated config to %s", study_update_path)
+        with open(study_update_path, 'wb') as study_update:
+            study_update.write(yaml.dump(updated_config).encode("utf-8"))
+
+    @classmethod
+    def load_updated_study_exec(cls, output_path):
+        """
+        Load the updated study config for the study rooted in 'out_path'.
+
+        :param out_path: A string containing the path to a study root.
+        :returns: A dict containing the updated config for the study.
+        """
+        study_update_path = os.path.join(output_path, cls._study_update)
+
+        if not os.path.exists(study_update_path):
+            # No update record found
+            return {}
+
+        with open(study_update_path, 'r') as data:
+            try:
+                updated_study_config = yaml.load(data, yaml.FullLoader)
+            except AttributeError:
+                LOGGER.warning(
+                    "*** PyYAML is using an unsafe version with a known "
+                    "load vulnerability. Please upgrade your installation "
+                    "to a more recent version! ***")
+                updated_study_config = yaml.load(data)
+
+        if updated_study_config:
+            LOGGER.debug("Successfully read updated study config; removing record at %s",
+                         study_update_path)
+            os.remove(study_update_path)
+
+        return updated_study_config
+
+    @property
+    def sleep_time(self):
+        return self._sleep_time
+
+    @sleep_time.setter
+    def sleep_time(self, new_sleep_time):
+        self._sleep_time = new_sleep_time
+
     def initialize(self, batch_info, sleeptime=60):
         """
         Initializes the Conductor instance based on the stored study.
@@ -318,6 +374,7 @@ class Conductor:
 
         # Set some fixed variables that monitor will use.
         cancel_lock_path = make_safe_path(self.output_path, self._cancel_lock)
+        study_update_path = make_safe_path(self.output_path, self._study_update)
         dag = self._exec_dag
         pkl_path = \
             os.path.join(self._pkl_path, "{}.pkl".format(self._study.name))
@@ -346,6 +403,26 @@ class Conductor:
                     LOGGER.error("Failed to acquire cancellation lock.")
                     pass
 
+            if os.path.exists(study_update_path):
+                updated_study_config = self.load_updated_study_exec(self.output_path)
+
+                if "throttle" in updated_study_config:
+                    LOGGER.info("Updating throttle from %d to %d",
+                                dag._submission_throttle,  # NOTE: make a property?
+                                updated_study_config["throttle"])
+                    dag.update_throttle(updated_study_config["throttle"])
+
+                if "rlimit" in updated_study_config:
+                    LOGGER.info("Updating restart limit to %d",
+                                updated_study_config["rlimit"])
+                    dag.update_rlimit(updated_study_config["rlimit"])
+
+                if "sleep" in updated_study_config:
+                    LOGGER.info("Updating conductor sleep time from %s to %s",
+                                str(self.sleep_time),
+                                str(updated_study_config["sleep"]))
+                    self.sleep_time = updated_study_config["sleep"]
+                    
             LOGGER.info("Checking DAG status at %s", str(datetime.now()))
             # Execute steps that are ready
             # Receives StudyStatus enum

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -84,6 +84,14 @@ class _StepRecord:
             self._params = {}
         return self._params
 
+    @property
+    def restart_limit(self):
+        return self._restart_limit
+
+    @restart_limit.setter
+    def restart_limit(self, new_restart_limit):
+        self._restart_limit = new_restart_limit
+
     def setup_workspace(self):
         """Initialize the record's workspace."""
         create_parentdir(self.workspace.value)
@@ -398,6 +406,27 @@ class ExecutionGraph(DAG, PickleInterface):
         # recreate it.
         if self._tmp_dir and not os.path.exists(self._tmp_dir):
             self._tmp_dir = tempfile.mkdtemp()
+
+    def update_throttle(self, new_submission_throttle):
+        self._submission_throttle = new_submission_throttle
+
+    def update_rlimit(self, new_restart_limit):
+        # subtree, _ = self.bfs_subtree(SOURCE)
+            
+        # update_subtree = [key for key in subtree
+        #                             if key != '_source']
+
+        for key in self.values.keys():
+            if key == SOURCE:
+                continue
+
+            # Get the step record to update
+            step_record = self.values[key]
+            LOGGER.debug("Updating restart limit from %d to %d for step '%s'",
+                         step_record.restart_limit,
+                         new_restart_limit,
+                         key)
+            step_record.restart_limit = new_restart_limit
 
     def add_step(self, name, step, workspace, restart_limit, params=None):
         """

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -174,8 +174,8 @@ def validate_update_args(args, directory_list):
 
     # Add rich formatting, or spin up logger here with stdout only handler?
     err_msg_template = "ERROR: {var_name} is incompatible with directory: "\
-        + "{var_name} have either 1 value (same value for all directories) " \
-        + "or the same number of values as study directories."
+        + "{var_name} must have either 1 value (same value for all " \
+        + "directories) or the same number of values as study directories."
     vars_are_valid = True
     for update_config_var in ['rlimit', 'throttle', 'sleep']:
         var_is_valid = validate_attr(args, update_config_var, directory_list)

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -261,7 +261,7 @@ def update_study_exec(args):
     for new_limits, directory in zip(expanded_update_args, directory_list):
         # new_limits = {}
         # Skip interactive mode if explicit args passed in
-        if new_limits:
+        if any([update_val for update_arg, update_val in new_limits.items()]):
             still_updating = False
         else:
             still_updating = True

--- a/maestrowf/maestro.py
+++ b/maestrowf/maestro.py
@@ -559,7 +559,7 @@ def setup_argparser():
     update.add_argument(
         "--throttle",
         action="append",
-        type=str,
+        type=int,
         default=[],
         help="Update the maximum number of inflight jobs allowed to execute"
         " simultaneously (0 denotes no throttling)."
@@ -567,7 +567,7 @@ def setup_argparser():
     update.add_argument(
         "--rlimit",
         action="append",
-        type=str,
+        type=int,
         default=[],
         help="Update the maximum number of restarts allowed when steps "
         "specify a restart command (0 denotes no limit)."
@@ -575,7 +575,7 @@ def setup_argparser():
     update.add_argument(
         "--sleep",
         action="append",
-        type=str,
+        type=int,
         default=[],
         help="Update the time (in seconds) that the manager will "
         "wait between job status checks.",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,11 @@ plugins:
     - literate-nav:
         nav_file: SUMMARY.md
     - glightbox
+    - termynal:
+        title: bash
+        prompt_literal_start:
+          - "$"
+          - ">"
     # - section-index
 
 extra_javascript:

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,21 +15,6 @@ files = [
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
-name = "astunparse"
-version = "1.6.3"
-description = "An AST unparser for Python"
-optional = false
-python-versions = "*"
-files = [
-    {file = "astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"},
-    {file = "astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872"},
-]
-
-[package.dependencies]
-six = ">=1.6.1,<2.0"
-wheel = ">=0.23.0,<1.0"
-
-[[package]]
 name = "attrs"
 version = "24.2.0"
 description = "Classes Without Boilerplate"
@@ -59,32 +44,8 @@ files = [
     {file = "babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"},
 ]
 
-[package.dependencies]
-pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
-
 [package.extras]
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
-
-[[package]]
-name = "beautifulsoup4"
-version = "4.12.3"
-description = "Screen-scraping library"
-optional = false
-python-versions = ">=3.6.0"
-files = [
-    {file = "beautifulsoup4-4.12.3-py3-none-any.whl", hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"},
-    {file = "beautifulsoup4-4.12.3.tar.gz", hash = "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"},
-]
-
-[package.dependencies]
-soupsieve = ">1.2"
-
-[package.extras]
-cchardet = ["cchardet"]
-chardet = ["chardet"]
-charset-normalizer = ["charset-normalizer"]
-html5lib = ["html5lib"]
-lxml = ["lxml"]
 
 [[package]]
 name = "cachetools"
@@ -400,16 +361,6 @@ files = [
 ]
 
 [[package]]
-name = "editorconfig"
-version = "0.12.4"
-description = "EditorConfig File Locator and Interpreter for Python"
-optional = false
-python-versions = "*"
-files = [
-    {file = "EditorConfig-0.12.4.tar.gz", hash = "sha256:24857fa1793917dd9ccf0c7810a07e05404ce9b823521c7dce22a4fb5d125f80"},
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
@@ -484,7 +435,6 @@ files = [
 ]
 
 [package.dependencies]
-astunparse = {version = ">=1.6", markers = "python_version < \"3.9\""}
 colorama = ">=0.4"
 
 [[package]]
@@ -615,20 +565,6 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
-
-[[package]]
-name = "jsbeautifier"
-version = "1.15.1"
-description = "JavaScript unobfuscator and beautifier."
-optional = false
-python-versions = "*"
-files = [
-    {file = "jsbeautifier-1.15.1.tar.gz", hash = "sha256:ebd733b560704c602d744eafc839db60a1ee9326e30a2a80c4adb8718adc1b24"},
-]
-
-[package.dependencies]
-editorconfig = ">=0.12.2"
-six = ">=1.13.0"
 
 [[package]]
 name = "jsonschema"
@@ -954,28 +890,6 @@ files = [
     {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
     {file = "mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443"},
 ]
-
-[[package]]
-name = "mkdocs-mermaid2-plugin"
-version = "1.1.1"
-description = "A MkDocs plugin for including mermaid graphs in markdown sources"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mkdocs-mermaid2-plugin-1.1.1.tar.gz", hash = "sha256:bea5f3cbe6cb76bad21b81e49a01e074427ed466666c5d404e62fe8698bc2d7c"},
-    {file = "mkdocs_mermaid2_plugin-1.1.1-py3-none-any.whl", hash = "sha256:4e25876b59d1e151ca33a467207b346404b4a246f4f24af5e44c32408e175882"},
-]
-
-[package.dependencies]
-beautifulsoup4 = ">=4.6.3"
-jsbeautifier = "*"
-mkdocs = ">=1.0.4"
-pymdown-extensions = ">=8.0"
-requests = "*"
-setuptools = ">=18.5"
-
-[package.extras]
-test = ["mkdocs-material"]
 
 [[package]]
 name = "mkdocstrings"
@@ -1316,17 +1230,6 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
-
-[[package]]
-name = "pytz"
-version = "2024.2"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
-    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
-]
 
 [[package]]
 name = "pyyaml"
@@ -1675,26 +1578,6 @@ files = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "75.2.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "setuptools-75.2.0-py3-none-any.whl", hash = "sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8"},
-    {file = "setuptools-75.2.0.tar.gz", hash = "sha256:753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.5.2)"]
-core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.11.*)", "pytest-mypy"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1717,17 +1600,6 @@ files = [
 ]
 
 [[package]]
-name = "soupsieve"
-version = "2.6"
-description = "A modern CSS selector implementation for Beautiful Soup."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
-    {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
-]
-
-[[package]]
 name = "tabulate"
 version = "0.9.0"
 description = "Pretty-print tabular data"
@@ -1740,6 +1612,23 @@ files = [
 
 [package.extras]
 widechars = ["wcwidth"]
+
+[[package]]
+name = "termynal"
+version = "0.12.2"
+description = "A lightweight and modern animated terminal window"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "termynal-0.12.2-py3-none-any.whl", hash = "sha256:62314dac6e77f1b7b64a251c2c90702eb6e6910f72ea9c6e5ef68d715b272709"},
+    {file = "termynal-0.12.2.tar.gz", hash = "sha256:cc2356bbf8650c16abd0558786251fabdde6b25e1125c1f091607ed3e422f7f2"},
+]
+
+[package.dependencies]
+markdown = ">=3"
+
+[package.extras]
+mkdocs = ["mkdocs (>=1.4)"]
 
 [[package]]
 name = "tomli"
@@ -1914,20 +1803,6 @@ files = [
 watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
-name = "wheel"
-version = "0.44.0"
-description = "A built-package format for Python"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "wheel-0.44.0-py3-none-any.whl", hash = "sha256:2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f"},
-    {file = "wheel-0.44.0.tar.gz", hash = "sha256:a29c3f2817e95ab89aa4660681ad547c0e9547f20e75b0562fe7723c9a2a9d49"},
-]
-
-[package.extras]
-test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
-
-[[package]]
 name = "zipp"
 version = "3.20.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1949,4 +1824,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "8e169dd2881da44de4f78d8072b3345bad152b584e7501035661ab3a526e8d85"
+content-hash = "b3de4bca516cf38559f448a39142800371cd3df2f33910af3ea57180a6b88dd7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,20 +44,10 @@ pyyaml = ">=4.2b1"
 rich = "*"
 six = "*"
 tabulate = "*"
-mkdocs-mermaid2-plugin = "^1.1.1"
+#mkdocs-mermaid2-plugin = "^1.1.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 coverage = "*"
-mkdocs = "<2.0"
-mkdocs-material = "*"
-mkdocs-material-extensions = "*"
-# mkdocs-mermaid2-plugin = "*"
-mkdocstrings = "*"
-mkdocstrings-python = "*"
-mkdocs-gen-files = "*"
-mkdocs-literate-nav = "*"       # Make sub groups here for docs, formatting, etc?
-mkdocs-glightbox = "*"
-pymdown-extensions = "*"
 flake8 = "*"
 pydocstyle = "*"
 pylint = "*"
@@ -67,6 +57,18 @@ pytest-cov = "*"
 pre-commit = "*"
 tox-travis = "*"
 tox-pyenv = "*"
+
+[tool.poetry.group.docs.dependencies]
+mkdocs = { version = "<2.0", python = "^3.9" }
+mkdocs-material = { version = "*", python = "^3.9" }
+mkdocs-material-extensions = { version = "*", python = "^3.9" }
+mkdocstrings = { version = "*", python = "^3.9" }
+mkdocstrings-python = { version = "*", python = "^3.9" }
+mkdocs-gen-files = { version = "*", python = "^3.9" }
+mkdocs-literate-nav = { version = "*", python = "^3.9" }
+mkdocs-glightbox = { version = "*", python = "^3.9" }
+pymdown-extensions = { version = "*", python = "^3.9" }
+termynal = { version = "*", python = "^3.9" }
 
 [tool.poetry.plugins."console_scripts"]
 "maestro" = "maestrowf.maestro:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,14 +37,12 @@ python = ">=3.8,<4.0"
 coloredlogs = "*"
 dill = "*"
 filelock = "*"
-# importlib_metadata = {version = "*", python = "<3.8"}
 jsonschema = ">=3.2.0"
 packaging = ">=22.0"
 pyyaml = ">=4.2b1"
 rich = "*"
 six = "*"
 tabulate = "*"
-#mkdocs-mermaid2-plugin = "^1.1.1"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "maestrowf"
-version = "1.1.11dev1"
+version = "1.1.11dev2"
 description = "A tool to easily orchestrate general computational workflows both locally and on supercomputers."
 license = "MIT License"
 classifiers = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,30 @@
+import argparse
+from maestrowf import maestro
+import pytest
+
+# NOTE: good place for property testing with hypothesis?
+@pytest.mark.parametrize(
+    "cli_args, args_are_valid",
+    [
+        (["--rlimit", "2", 'study_workspace_1'], True),
+        (["--rlimit", "2", 'study_workspace_1', 'study_workspace_2'], True),
+        (["--rlimit", "2", "--rlimit", "3", 'study_workspace_1'], False),
+        (["--rlimit", "2", "--sleep", "30", 'study_workspace_1'], True),
+        (["--rlimit", "2", "--sleep", "30", 'study_workspace_1', 'study_workspace_2'], True),
+        (["--rlimit", "2", "--sleep", "30", "--sleep", "32", 'study_workspace_1', 'study_workspace_2'], True),
+        (["--rlimit", "2", "--sleep", "30", "--sleep", "32", "--sleep", "33", 'study_workspace_1', 'study_workspace_2'], False),
+        (["--rlimit", "2", "--sleep", "30", "--sleep", "32", 'study_workspace_1', 'study_workspace_2', 'study_workspace_3'], True),
+    ]
+)
+def test_validate_update_args(cli_args, args_are_valid):
+    """
+    Test validation of arguments passed to the 'maestro update' cli command
+    """
+    parser = maestro.setup_argparser()
+    maestro_cli = ["update"]
+
+    maestro_cli.extend(cli_args)
+    print(f"{maestro_cli=}")
+    args = parser.parse_args(maestro_cli)
+    # assert args is None
+    assert maestro.validate_update_args(args, args.directory) is args_are_valid

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ import pytest
         (["--rlimit", "2", "--sleep", "30", 'study_workspace_1', 'study_workspace_2'], True),
         (["--rlimit", "2", "--sleep", "30", "--sleep", "32", 'study_workspace_1', 'study_workspace_2'], True),
         (["--rlimit", "2", "--sleep", "30", "--sleep", "32", "--sleep", "33", 'study_workspace_1', 'study_workspace_2'], False),
-        (["--rlimit", "2", "--sleep", "30", "--sleep", "32", 'study_workspace_1', 'study_workspace_2', 'study_workspace_3'], True),
+        (["--rlimit", "2", "--sleep", "30", "--sleep", "32", 'study_workspace_1', 'study_workspace_2', 'study_workspace_3'], False),
     ]
 )
 def test_validate_update_args(cli_args, args_are_valid):
@@ -28,3 +28,55 @@ def test_validate_update_args(cli_args, args_are_valid):
     args = parser.parse_args(maestro_cli)
     # assert args is None
     assert maestro.validate_update_args(args, args.directory) is args_are_valid
+
+
+@pytest.mark.parametrize(
+    "cli_args, expected_expanded_args",
+    [
+        (
+            ["--rlimit", "2", 'study_workspace_1'],
+            [{'rlimit': 2, 'throttle': None, 'sleep': None}, ]
+        ),
+        (
+            ["--rlimit", "2", 'study_workspace_1', 'study_workspace_2'],
+            [
+                {'rlimit': 2, 'throttle': None, 'sleep': None},
+                {'rlimit': 2, 'throttle': None, 'sleep': None}
+            ]
+        ),
+        (
+            ["--rlimit", "2", "--sleep", "30", 'study_workspace_1'],
+            [{'rlimit': 2, 'sleep': 30, 'throttle': None}, ]
+        ),
+        (
+            ["--rlimit", "2", "--sleep", "30", 'study_workspace_1', 'study_workspace_2'],
+            [
+                {'rlimit': 2, 'sleep': 30, 'throttle': None},
+                {'rlimit': 2, 'sleep': 30, 'throttle': None}
+            ]
+        ),
+        (
+            ["--rlimit", "2", "--sleep", "30", "--sleep", "32", 'study_workspace_1', 'study_workspace_2'],
+            [
+                {'rlimit': 2, 'sleep': 30, 'throttle': None},
+                {'rlimit': 2, 'sleep': 32, 'throttle': None}
+            ],
+        ),
+    ]
+)
+def test_expand_update_args(cli_args, expected_expanded_args):
+    """
+    Test expansion of arguments passed to the 'maestro update' cli command,
+    i.e. repeating single values for all study workspaces being updated
+    """
+    parser = maestro.setup_argparser()
+    maestro_cli = ["update"]
+
+    maestro_cli.extend(cli_args)
+    print(f"{maestro_cli=}")
+    args = parser.parse_args(maestro_cli)
+    expanded_args = maestro.expand_update_args(args, args.directory)
+    print(f"{args=}")
+    print(f"{expanded_args=}")
+    print(f"{expected_expanded_args=}")
+    assert expanded_args == expected_expanded_args

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
-import argparse
 from maestrowf import maestro
+from maestrowf.conductor import Conductor
+
 import pytest
+
+from rich.pretty import pprint
 
 # NOTE: good place for property testing with hypothesis?
 @pytest.mark.parametrize(
@@ -80,3 +83,34 @@ def test_expand_update_args(cli_args, expected_expanded_args):
     print(f"{expanded_args=}")
     print(f"{expected_expanded_args=}")
     assert expanded_args == expected_expanded_args
+
+
+@pytest.mark.parametrize(
+    "cli_args, expected_lock_dict",
+    [
+        (
+            ["--rlimit", "2"],
+            {'rlimit': 2, 'throttle': None, 'sleep': None},
+        ),
+    ]
+)
+def test_write_update_args(cli_args, expected_lock_dict, tmp_path):
+    """
+    Test writing and reading of study config updates,
+    """
+    parser = maestro.setup_argparser()
+    maestro_cli = ["update"]
+
+    maestro_cli.extend(cli_args)
+    pprint(f"{tmp_path=}")
+    maestro_cli.append(str(tmp_path))
+    print(f"{maestro_cli=}")
+    args = parser.parse_args(maestro_cli)
+    print(f"{args=}")
+    print(f"{expected_lock_dict=}")
+
+    maestro.update_study_exec(args)
+
+    update_dict = Conductor.load_updated_study_exec(tmp_path)
+
+    assert update_dict == expected_lock_dict


### PR DESCRIPTION
This feature adds the ability to change some of a study's configuration during execution, including:

- rlimit (restart limit)
- throttle
- sleep

Implementation works like cancel, taking paths to executing study workspaces.  Configuration parameters can be updated either via an interactive prompt for each study workspace given, or using explicit/repeated keyword arguments for each configuration parameter.  

Current Limitations:

- rlimit is a per step configuration, but it is only set globally in current implementation
- If a study is no longer running, updating rlimit will not yet resume the study to account for any increases