### PR TITLE
Update flux exclusive behavior modify task info passed to allocation/launcher

### DIFF
--- a/docs/Maestro/scheduling.md
+++ b/docs/Maestro/scheduling.md
@@ -24,12 +24,12 @@ steps:
 | `flux_uri`        | Yes*          | str      | URI of the Flux instance to schedule jobs to. * Only used with `type`=`flux`. NOTE: It is recommended to rely on environment variables instead, as URIs are very ephemeral and may change frequently. |
 | `version`         | No            | str      | Optional version of flux scheduler; for accommodating api changes                                                                                                                                     |
 | :warning: `args`  | No            | dict     | Optional additional args to pass to scheduler; keys are arg names, values are arg values                                                                                                              |
-| `allocation_args` | No            | dict     | Optional scheduler specific options/flags to add to allocations :material-information-slab-circle: flux only in :material-tag:`1.1.12`                                                                |
-| `launcher_args`   | No            | dict     | Optional scheduler specific options/flags to add to launcher commands :material-information-slab-circle: flux only in :material-tag:`1.1.12`                                                          |
+| `allocation_args` | No            | dict     | Optional scheduler specific options/flags to add to allocations :material-information-slab-circle: flux only in :material-tag:`1.2.0`                                                                |
+| `launcher_args`   | No            | dict     | Optional scheduler specific options/flags to add to launcher commands :material-information-slab-circle: flux only in :material-tag:`1.2.0`                                                          |
 
 !!! warning "`args` deprecated"
 
-    `args` has been marked deprecated in :material-tag: `1.1.12` in favor of the more flexible `allocation_args` and `launcher_args`
+    `args` has been marked deprecated in :material-tag: `1.2.0` in favor of the more flexible `allocation_args` and `launcher_args`
 
 The information in this block is used to populate the step specific batch scripts with the appropriate
 header comment blocks (e.g. '#SBATCH --partition' for slurm).  Additional keys such as step specific
@@ -47,7 +47,7 @@ run locally unless at least the ``nodes`` or ``procs`` key in the step is popula
 ### Extra Arguments
 ---
 
-There are new groups in the batch block in :material-tag:`1.1.12` that facilitate adding custom options to both allocations and the `$(LAUNCHER)` invocations independently.  These are grouped into two dictionaries in the batch block which are meant to enable passing in options that Maestro cannot abstract across schedulers more generally:
+There are new groups in the batch block in :material-tag:`1.2.0` that facilitate adding custom options to both allocations and the `$(LAUNCHER)` invocations independently.  These are grouped into two dictionaries in the batch block which are meant to enable passing in options that Maestro cannot abstract across schedulers more generally:
 
 * `allocation_args` for the allocation target (batch directives such as `#Flux: --setopt=foo=bar`)
 * `launcher_args` for the `$(LAUNCHER)` target (`flux run --setopt=foo=bar`)
@@ -216,7 +216,7 @@ See the [flux framework](https://flux-framework.readthedocs.io/en/latest/index.h
 ### Extra Flux Args
 ----
 
-As of :material-tag:`1.1.12`, the flux adapter takes advantage of new argument pass through for scheduler options that Maestro cannot abstract away.  This is done via `allocation_args` and `launcher_args` in the batch block, which expand upon the previous `args` input which only applied to `$(LAUNCHER)`.  There are some caveat's here due to the way Maestro talks to flux.  The current flux adapters all use the python api's from Flux to build the batch jobs, with the serialized batch script being serialized separately instead of submitted directly as with the other schedulers.  A consequence of this is the `allocation_args` map to specific call points on that python api, and thus the option pass through is not quite arbitrary.  There are 4 currently supported options for allocations which cover a majority of usecases (open an issue and let us know if there is a usecase you need that is not covered!):
+As of :material-tag:`1.2.0`, the flux adapter takes advantage of new argument pass through for scheduler options that Maestro cannot abstract away.  This is done via `allocation_args` and `launcher_args` in the batch block, which expand upon the previous `args` input which only applied to `$(LAUNCHER)`.  There are some caveat's here due to the way Maestro talks to flux.  The current flux adapters all use the python api's from Flux to build the batch jobs, with the serialized batch script being serialized separately instead of submitted directly as with the other schedulers.  A consequence of this is the `allocation_args` map to specific call points on that python api, and thus the option pass through is not quite arbitrary.  There are 4 currently supported options for allocations which cover a majority of usecases (open an issue and let us know if there is a usecase you need that is not covered!):
 
 * shell options: `-o/--setopt` prefixed arguments
 * attributes: `-S/--setattr` prefixed arguments

--- a/docs/Maestro/scheduling.md
+++ b/docs/Maestro/scheduling.md
@@ -9,23 +9,23 @@ steps:
 <!-- There a way to add a title to a table? -->
 **Batch block keys**
 
-|  **Key**      | **Required?**  | **Type** | **Description** |
-|    :-         |      :-:       |    :-:   |       :-        |
-|  `type`       |      Yes        |   str    | Select scheduler adapter to use.  Currently supported are: {`local`, `slurm`, `lsf`, `flux`} |
-|  `shell`      |      No        |   str    | Optional specification path to shell to use for execution.  Defaults to `"/bin/bash"` |
-| `bank` (1)        |      Yes       |   str    | Account which runs the job; this is used for computing job priority on the cluster. '--account' on slurm, '-G' on lsf, ...|
-| `host`        |      Yes       |   str    | The name of the cluster to execute this study on |
-| `queue` (2)       |      Yes       |   str    | Scheduler queue/machine partition to submit jobs (study steps) to |
-| `nodes`       |      No        |   int    | Number of compute nodes to be reserved for jobs: note this is also a per step key |
-| `reservation` |      No        |   str    | Optional prereserved allocation/partition to submit jobs to |
-| `qos`         |      No        |   str    | Quality of service specification -> i.e. run in standby mode to use idle resources when user priority is low/job limits already reached |
-| `gpus`        |      No        |   str    | Optional reservation of gpu resources for jobs |
-| `procs`       |      No        |   int    | Optional number of tasks in batch allocations: note this is also a per step key |
-| `flux_uri`    |      Yes*      |   str    | URI of the Flux instance to schedule jobs to. * Only used with `type`=`flux`. NOTE: It is recommended to rely on environment variables instead, as URIs are very ephemeral and may change frequently.|
-| `version`     |      No        |   str    | Optional version of flux scheduler; for accommodating api changes |
-| :warning: `args`        |      No        |   dict   | Optional additional args to pass to scheduler; keys are arg names, values are arg values |
-| `allocation_args` | No  | dict | Optional scheduler specific options/flags to add to allocations :material-information-slab-circle: flux only in :material-tag:`1.1.12` |
-| `launcher_args` | No  | dict | Optional scheduler specific options/flags to add to launcher commands :material-information-slab-circle: flux only in :material-tag:`1.1.12` |
+| **Key**           | **Required?** | **Type** | **Description**                                                                                                                                                                                       |
+|:------------------|:-------------:|:--------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `type`            | Yes           | str      | Select scheduler adapter to use.  Currently supported are: {`local`, `slurm`, `lsf`, `flux`}                                                                                                          |
+| `shell`           | No            | str      | Optional specification path to shell to use for execution.  Defaults to `"/bin/bash"`                                                                                                                 |
+| `bank` (1)        | Yes           | str      | Account which runs the job; this is used for computing job priority on the cluster. '--account' on slurm, '-G' on lsf, ...                                                                            |
+| `host`            | Yes           | str      | The name of the cluster to execute this study on                                                                                                                                                      |
+| `queue` (2)       | Yes           | str      | Scheduler queue/machine partition to submit jobs (study steps) to                                                                                                                                     |
+| `nodes`           | No            | int      | Number of compute nodes to be reserved for jobs: note this is also a per step key                                                                                                                     |
+| `reservation`     | No            | str      | Optional prereserved allocation/partition to submit jobs to                                                                                                                                           |
+| `qos`             | No            | str      | Quality of service specification -> i.e. run in standby mode to use idle resources when user priority is low/job limits already reached                                                               |
+| `gpus`            | No            | str      | Optional reservation of gpu resources for jobs                                                                                                                                                        |
+| `procs`           | No            | int      | Optional number of tasks in batch allocations: note this is also a per step key                                                                                                                       |
+| `flux_uri`        | Yes*          | str      | URI of the Flux instance to schedule jobs to. * Only used with `type`=`flux`. NOTE: It is recommended to rely on environment variables instead, as URIs are very ephemeral and may change frequently. |
+| `version`         | No            | str      | Optional version of flux scheduler; for accommodating api changes                                                                                                                                     |
+| :warning: `args`  | No            | dict     | Optional additional args to pass to scheduler; keys are arg names, values are arg values                                                                                                              |
+| `allocation_args` | No            | dict     | Optional scheduler specific options/flags to add to allocations :material-information-slab-circle: flux only in :material-tag:`1.1.12`                                                                |
+| `launcher_args`   | No            | dict     | Optional scheduler specific options/flags to add to launcher commands :material-information-slab-circle: flux only in :material-tag:`1.1.12`                                                          |
 
 !!! warning "`args` deprecated"
 
@@ -54,12 +54,12 @@ There are new groups in the batch block in :material-tag:`1.1.12` that facilitat
 
 These are ~structured mappings which are designed to mimic cli and batch script directive syntax for intuitive mapping from raw scheduler usage to Maestro.  Each of these dictionaries' keys correspond to a scheduler specific CLI argument/option or flag.  The serialization rules are as follows, with specific examples here shown for the initial implementation in the flux adapter (other schedulers will yield prefix/separator rules specific to their implementation):
 
-|  **Key Type**         | **Prefix** | **Separator** | **Example YAML**     | **Example CLI Input/Directive** |
-|    :-                 | :-            | :-       |    :-                |       :-               |
-|  Single letter        |  `-`           | `" "` (space) | <pre><code><span>o:</span></br><span>  bar: 42</span></code></pre>       | `-o bar=42`            |
-|  Multi-letter         | `--`           |  `=`          | <pre><code><span>setopt:</span></br><span>  foo: bar</span></code></pre> | `--setopt=foo=bar`     |
-|  Boolean flag w/key   | as above       | as above      | <pre><code><span>setopt:</span></br><span>  foobar: #</span></code></pre> | `--setopt=foobar`      |
-|  Boolean flag w/o key | as above       | as above      | `exclusive: #`        | `--exclusive`      |
+| **Key Type**         | **Prefix** | **Separator** | **Example YAML**                                                          | **Example CLI Input/Directive** |
+|:---------------------|:-----------|:--------------|:--------------------------------------------------------------------------|:--------------------------------|
+| Single letter        | `-`        | `" "` (space) | <pre><code><span>o:</span></br><span>  bar: 42</span></code></pre>        | `-o bar=42`                     |
+| Multi-letter         | `--`       | `=`           | <pre><code><span>setopt:</span></br><span>  foo: bar</span></code></pre>  | `--setopt=foo=bar`              |
+| Boolean flag w/key   | as above   | as above      | <pre><code><span>setopt:</span></br><span>  foobar: #</span></code></pre> | `--setopt=foobar`               |
+| Boolean flag w/o key | as above   | as above      | `exclusive: #`                                                            | `--exclusive`                   |
 
 !!! note "Boolean/Flag type arguments"
 

--- a/docs/Maestro/specification.md
+++ b/docs/Maestro/specification.md
@@ -427,16 +427,16 @@ Additionally there are more fine grained resource/scheduler control enabled by t
 The following keys are all optional and get into scheduler specific features.  See the respective sections
 before using them: 
 
-|  **Key**         | **Type**     | **Description**                                               |
-|    :-            |   :-:        |       :-                                                      |
-| `cores per task` |   str/int    | Number of cores to use for each task        |
-|  `exclusive`     |   str        | Flag for ensuring batch job has exclusive access to it's requested resources |
-|  `gpus`          |   str/int    | Number of gpus to allocate with this step |
-|  `tasks per rs`  |   str/int    | Number of tasks per resource set (LSF/jsrun) |
-|  `rs per node`   |   str/int    | Number of resource sets per node |
-|  `cpus per rs`   |   str/int    | Number of cpus in each resource set |
-|  `bind`          |   str        | Controls binding of tasks in resource sets |
-|  `bind gpus`     |   str        | Controls binding of gpus in resource sets |
+| **Key**          | **Type**  | **Description**                                                              |
+|:-----------------|:---------:|:-----------------------------------------------------------------------------|
+| `cores per task` | str/int   | Number of cores to use for each task                                         |
+| `exclusive`      | bool/dict | Controls whether `--exclusive` is applied for HPC scheduling. Accepts either:<br><br>- **`bool`**: legacy shortcut, applies **only to the allocation/batch job** (equivalent to `{ allocation: true/false }`). This remains the common case.<br>- **`dict`**: set exclusivity independently for the allocation and the launcher. Supported keys:<br>  - `allocation` (bool): apply `--exclusive` to the batch job/allocation request.<br>  - `launcher` (bool): apply `--exclusive` to the job launcher command (for example `flux run`, `srun`, etc). |
+| `gpus`           | str/int   | Number of gpus to allocate with this step                                    |
+| `tasks per rs`   | str/int   | Number of tasks per resource set (LSF/jsrun)                                 |
+| `rs per node`    | str/int   | Number of resource sets per node                                             |
+| `cpus per rs`    | str/int   | Number of cpus in each resource set                                          |
+| `bind`           | str       | Controls binding of tasks in resource sets                                   |
+| `bind gpus`      | str       | Controls binding of gpus in resource sets                                    |
 
 
 ## Parameters: `global.parameters`

--- a/docs/Maestro/specification.md
+++ b/docs/Maestro/specification.md
@@ -430,7 +430,7 @@ before using them:
 | **Key**          | **Type**  | **Description**                                                              |
 |:-----------------|:---------:|:-----------------------------------------------------------------------------|
 | `cores per task` | str/int   | Number of cores to use for each task                                         |
-| `exclusive`      | bool/dict | Controls whether `--exclusive` is applied for HPC scheduling. Accepts either:<br><br>- **`bool`**: legacy shortcut, applies **only to the allocation/batch job** (equivalent to `{ allocation: true/false }`). This remains the common case.<br>- **`dict`**: set exclusivity independently for the allocation and the launcher. Supported keys:<br>  - `allocation` (bool): apply `--exclusive` to the batch job/allocation request.<br>  - `launcher` (bool): apply `--exclusive` to the job launcher command (for example `flux run`, `srun`, etc). |
+| `exclusive` | bool/dict | Request exclusive allocation of resources. Accepts either:<br><ul><li><strong><code>bool</code></strong>: legacy shortcut, applies <strong>only to the allocation/batch job</strong> (equivalent to <code>{ allocation: true/false }</code>). This is the most common usecase.</li><li><strong><code>dict</code></strong>: set exclusivity independently for the allocation and the launcher.<br>Supported keys:<ul><li><code>allocation</code> (bool): apply <code>--exclusive</code> to the batch job/allocation request.</li><li><code>launcher</code> (bool): apply <code>--exclusive</code> to the job launcher command (e.g. <code>flux run</code>, <code>srun</code>, etc).</li></ul></li></ul> |
 | `gpus`           | str/int   | Number of gpus to allocate with this step                                    |
 | `tasks per rs`   | str/int   | Number of tasks per resource set (LSF/jsrun)                                 |
 | `rs per node`    | str/int   | Number of resource sets per node                                             |
@@ -438,6 +438,128 @@ before using them:
 | `bind`           | str       | Controls binding of tasks in resource sets                                   |
 | `bind gpus`      | str       | Controls binding of gpus in resource sets                                    |
 
+
+#### Exclusive examples
+----
+
+!!! warning
+	
+	Many schedulers require specifying `nodes` when setting resource exclusivity.  Job failures may occur if
+	attempting to use `exclusive` without `nodes`, especially when used with launcher as not all schedulers
+	validate those launcher lines at job submission time (i.e. flux).  Maestro will also emit warnings and
+	errors in it's logs as it's building up the allocation and launcher configs, bit it does not yet stop
+	the study from executing
+	
+=== "Scalar exclusive"
+
+	
+    <div class="grid" markdown>
+    
+    ``` yaml title="Maestro step"
+    - name: run-exclusive-alloc
+      description: Simple exclusive allocation
+      run:
+          cmd: |
+            $(LAUNCHER) par_app_1
+          nodes: 2
+          procs: 72
+          exclusive   : True
+          walltime: "00:10:00
+    ```
+	
+	=== "slurm"
+	
+	    ``` bash title="Slurm batch script"
+		#SBATCH -N 1
+		...
+		#SBATCH --exclusive
+		srun -N 2 -n 72 myapplication
+        ```
+	
+	=== "flux"
+	
+    	``` bash title="flux batch script"
+		#flux: -N 1
+		...
+		#flux: --exclusive
+		flux run -N 2 -n 72 myapplication
+        ```
+	
+    </div>
+
+=== "Mapping exclusive: allocation only"
+
+
+    <div class="grid" markdown>
+    
+    ``` yaml title="Maestro step"
+    - name: run-exclusive-alloc
+      description: Simple exclusive allocation
+      run:
+          cmd: |
+            $(LAUNCHER) par_app_1
+          nodes: 2
+          procs: 72
+          exclusive: 
+		    allocation: true
+          walltime: "00:10:00
+    ```
+	
+	=== "slurm"
+	
+	    ``` bash title="Slurm batch script"
+		#SBATCH -N 1
+		...
+		#SBATCH --exclusive
+		srun -N 2 -n 72 myapplication
+        ```
+	
+	=== "flux"
+	
+    	``` bash title="flux batch script"
+		#flux: -N 1
+		...
+		#flux: --exclusive
+		flux run -N 2 -n 72 myapplication
+        ```
+    </div>
+	
+=== "Mapping exclusive: allocation and launcher"
+
+    <div class="grid" markdown>
+    
+    ``` yaml title="Maestro step"
+    - name: run-exclusive-alloc
+      description: Simple exclusive allocation
+      run:
+          cmd: |
+            $(LAUNCHER) par_app_1
+          nodes: 2
+          procs: 72
+          exclusive: 
+		    allocation: true
+			launcher: true
+          walltime: "00:10:00
+    ```
+	
+	=== "slurm"
+	
+	    ``` bash title="Slurm batch script"
+		#SBATCH -N 1
+		...
+		#SBATCH --exclusive
+		srun -N 2 -n 72 --exclusive myapplication
+        ```
+	
+	=== "flux"
+	
+    	``` bash title="flux batch script"
+		#flux: -N 1
+		...
+		#flux: --exclusive
+		flux run -N 2 -n 72 --exclusive myapplication
+        ```
+    </div>
 
 ## Parameters: `global.parameters`
 ----

--- a/docs/Maestro/specification.md
+++ b/docs/Maestro/specification.md
@@ -442,6 +442,16 @@ before using them:
 #### Exclusive examples
 ----
 
+!!! info
+
+	Flux specifically has a behavior change in :material-tag:`1.2.0`: when using exclusive on the allocation
+	everything but the `nodes` key will be omitted from the allocation/batch script to force a single slot
+	per node with everything.  Prior behavior attached tasks (`procs`) to the allocation too, which could 
+	interfere with multiple Launcher task shapes, or in the case of configurable hardware (subdividing GPU's),
+	lead to failed job submissions due to unsatisfiable resource shapes.  If you have a use case for
+	configuring slots at the allocation level get in touch with us to discuss options/future features.
+	
+	
 !!! warning
 	
 	Many schedulers require specifying `nodes` when setting resource exclusivity.  Job failures may occur if

--- a/docs/Maestro/study_workspaces.md
+++ b/docs/Maestro/study_workspaces.md
@@ -135,7 +135,7 @@ Some concerns to be mindful of here is that you may want to prevent the yaml rea
 
 Currently the only two ways to control step workspace names are via the string typing control of floats described above, and a cli argument to the `maestro run` command: `--hashws`.  Hashing can be a critical option in certain studies; large numbers of parameters, parameters that may be specifying paths or other long strings, or string representations of floating point numbers that require full 17+ digits can all lead to exceeding the system path and/or name length limits.  Hashing is an option to mitigate this.  However, going forward the new sortable algorithm should prove more desirable for it's improved readability and compactness in all cases.
 
-#### MD5 algorithm (pre-:material-tag:`1.1.12`)
+#### MD5 algorithm (pre-:material-tag:`1.2.0`)
 
 Initial implementation simply ran the string form of the steps' parameter combination through the md5 hashing algorithm.  While this guarantees uniqueness, and does a good job limiting the size of the resulting paths, it is not very human friendly:
 
@@ -152,7 +152,7 @@ Initial implementation simply ran the string form of the steps' parameter combin
 ![Workspaces Demo Study Layout With MD5 Step Hashing](../assets/images/examples/workspaces/md5_hashed_study_workspace.svg)
 
 
-#### Sortable Hash (>=:material-tag:`1.1.12`)
+#### Sortable Hash (>=:material-tag:`1.2.0`)
 
 In Maestro >:material-tag:`1.1.11`, the md5 algorithm is replaced with an alternative that's more human readable, maintaining compactness, but also introducting sortable naming.  Technically this is not a hash function as it cannot be applied to parameter combination strings independently, rather requiring knowledge of all instances of a step to apply a count based identifier.  The format of this is as follows:
 

--- a/maestrowf/interfaces/script/_flux/flux0_49_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_49_0.py
@@ -423,7 +423,7 @@ class FluxInterface_0490(FluxInterface):
     @classmethod
     def parallelize(cls, procs, nodes=None, launcher_args=None, **kwargs):
 
-        args = ["flux", "run"]  #, "-n", str(procs)]
+        args = ["flux", "run"]
         
         exclusive = kwargs.pop('exclusive', False)
         
@@ -431,9 +431,6 @@ class FluxInterface_0490(FluxInterface):
         if nodes is not None and nodes != '':
             args.append("-N")
             args.append(str(nodes))
-        # ntasks = nodes if nodes else 1
-        # args.append("-N")
-        # args.append(str(ntasks))
 
         # NOTE: should we raise an exception here instead of just logging the error?
         #       better pre-run validation might be more useful...
@@ -452,17 +449,11 @@ class FluxInterface_0490(FluxInterface):
         
         if cores_per_task is not None and cores_per_task != '' and not exclusive:
             args.append("-c")
-            # Error checking -> more comprehensive handling in base schedulerscriptadapter?
-            # if not kwargs["cores per task"]:
-            #     cores_per_task = 1
-            # else:
-            #     cores_per_task = kwargs["cores per task"]
-
-            # args.append(str(kwargs["cores per task"]))
+            # TODO: more comprehensive handling in base schedulerscriptadapter?
             args.append(str(cores_per_task))
 
             LOGGER.info("Adding 'cores per task' %s to flux args",
-                        str(kwargs["cores per task"]))
+                        str(cores_per_task))
 
         ngpus = kwargs.get("gpus", 0)
         if ngpus and ngpus != '' and not exclusive:

--- a/maestrowf/interfaces/script/_flux/flux0_49_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_49_0.py
@@ -321,7 +321,12 @@ class FluxInterface_0490(FluxInterface):
                 )
                 # Need to attach broker opts to the constructor?
                 # TODO: Add in extra broker options if not null
-                ngpus_per_slot = int(ceil(ngpus / nodes))
+                # ngpus_per_slot = int(ceil(ngpus / nodes))
+                if nodes:
+                    ngpus_per_slot = int(ceil(ngpus / nodes))
+                else:
+                    ngpus_per_slot = None
+                LOGGER.warn(f"NODES recieved: {nodes}")
                 jobspec = flux.job.JobspecV1.from_nest_command(
                     [path],
                     num_nodes=nodes,
@@ -418,20 +423,40 @@ class FluxInterface_0490(FluxInterface):
     @classmethod
     def parallelize(cls, procs, nodes=None, launcher_args=None, **kwargs):
 
-        args = ["flux", "run", "-n", str(procs)]
-
+        args = ["flux", "run"]  #, "-n", str(procs)]
+        
+        exclusive = kwargs.pop('exclusive', False)
+        
         # if we've specified nodes, add that to wreckrun
-        ntasks = nodes if nodes else 1
-        args.append("-N")
-        args.append(str(ntasks))
+        if nodes is not None and nodes != '':
+            args.append("-N")
+            args.append(str(nodes))
+        # ntasks = nodes if nodes else 1
+        # args.append("-N")
+        # args.append(str(ntasks))
 
-        if "cores per task" in kwargs:
+        # NOTE: should we raise an exception here instead of just logging the error?
+        #       better pre-run validation might be more useful...
+        #       or should we just prune the exclusive flag and run it anyway?
+        if procs and (nodes is None or nodes == '') and exclusive:
+            LOGGER.error(
+                "Invalid use of exclusive on launcher: "
+                "exclusive can only be set with a node count"
+            )
+
+        if procs:
+            args.append("-n")
+            args.append(str(procs))
+
+        cores_per_task = kwargs.get("cores per task", None)
+        
+        if cores_per_task is not None and cores_per_task != '' and not exclusive:
             args.append("-c")
             # Error checking -> more comprehensive handling in base schedulerscriptadapter?
-            if not kwargs["cores per task"]:
-                cores_per_task = 1
-            else:
-                cores_per_task = kwargs["cores per task"]
+            # if not kwargs["cores per task"]:
+            #     cores_per_task = 1
+            # else:
+            #     cores_per_task = kwargs["cores per task"]
 
             # args.append(str(kwargs["cores per task"]))
             args.append(str(cores_per_task))
@@ -440,7 +465,7 @@ class FluxInterface_0490(FluxInterface):
                         str(kwargs["cores per task"]))
 
         ngpus = kwargs.get("gpus", 0)
-        if ngpus:
+        if ngpus and ngpus != '' and not exclusive:
             gpus = str(ngpus)
             args.append("-g")
             args.append(gpus)
@@ -451,8 +476,6 @@ class FluxInterface_0490(FluxInterface):
             launcher_args = {}
 
         # Look for optional exclusive flag
-        exclusive = kwargs.pop('exclusive', False)
-
         addtl = []
         LOGGER.info("Processing 'exclusive': %s", exclusive)
         if exclusive:
@@ -461,7 +484,7 @@ class FluxInterface_0490(FluxInterface):
         addtl_args = kwargs.get("addtl_args", {})
         if addtl_args and launcher_args:
             # TODO: better way to mark things deprecated that's not buried?
-            LOGGER.warn("'args' input is deprecated in v1.1.12.  Use the more "
+            LOGGER.warn("'args' input is deprecated in v1.2.  Use the more "
                         "flexible 'launcher_args' going forward. Combining.")
         if 'o' in launcher_args:
             launcher_args['o'].update(**addtl_args)

--- a/maestrowf/interfaces/script/_flux/flux0_49_0.py
+++ b/maestrowf/interfaces/script/_flux/flux0_49_0.py
@@ -322,11 +322,11 @@ class FluxInterface_0490(FluxInterface):
                 # Need to attach broker opts to the constructor?
                 # TODO: Add in extra broker options if not null
                 # ngpus_per_slot = int(ceil(ngpus / nodes))
-                if nodes:
+                if nodes and not exclusive:
                     ngpus_per_slot = int(ceil(ngpus / nodes))
                 else:
                     ngpus_per_slot = None
-                LOGGER.warn(f"NODES recieved: {nodes}")
+
                 jobspec = flux.job.JobspecV1.from_nest_command(
                     [path],
                     num_nodes=nodes,

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -95,7 +95,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
 
         # NOTE: Host doesn"t seem to matter for FLUX. sbatch assumes that the
         # current host is where submission occurs.
-        self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
+        # self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
         self._allocation_args = kwargs.get("allocation_args", {})
         LOGGER.info(f"Allocation args: {self._allocation_args}")
         self._launcher_args = kwargs.get("launcher_args", {})
@@ -264,9 +264,25 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         batch_header["walltime"] = \
             str(self._convert_walltime_to_seconds(walltime))
 
-        if run["nodes"]:
+        # Unpack exclusive to modify procs/core per task
+        step_exclusive = step.run.get("exclusive", None)
+
+        step_exclusive = self.resolve_exclusive(self._exclusive, step_exclusive)
+
+        nodes = run.get("nodes", None)
+        LOGGER.info("Retrived 'nodes' from the step: '%s'", nodes)
+        print(f"INFO: retrieved 'nodes' from step: '{nodes}'")
+        if nodes is not None and nodes != '':  # catch nodes = 0 here?
             batch_header["nodes"] = run.pop("nodes")
-        if run["procs"]:
+
+        # Abusing 'truthiness' here to catch '' values too
+        elif not nodes and step_exclusive['allocation']:
+            LOGGER.error(
+                "Invalid use of exclusive on allocation: "
+                "exclusive can only be set with a node count"
+            )
+
+        if run["procs"] and not step_exclusive['allocation']:
             batch_header["procs"] = run.pop("procs")
         batch_header["job-name"] = step.name.replace(" ", "_")
         batch_header["comment"] = step.description.replace("\n", " ")
@@ -278,12 +294,11 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
 
         modified_header = ["#!{}".format(self._exec)]
 
-        # Process INFO lines at the start to 
-        # lines starting tag+prefix (e.g. "#flux:" ) that doesn't match the flux directives
+        # Process INFO lines at the start to avoid interrupting flux directives
         for key, value in self._header_info.items():
             modified_header.append(value.format(**batch_header))
 
-        # Inject a blank # comment line between the flux directives for readability
+        # Inject a blank # comment line between the info/flux directives for readability
         modified_header.append("#")
 
         for key, value in self._header.items():
@@ -293,13 +308,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
 
             modified_header.append(value.format(**batch_header))
 
-        # Handle exclusive flag
-        # Handle the exclusive flags, updating batch block settings (default)
-        # with what's set in the step, if any given
-        step_exclusive = step.run.get("exclusive", None)
-
-        step_exclusive = self.resolve_exclusive(self._exclusive, step_exclusive)
-
+        # Add exclusive flag to header if requested
         if step_exclusive['allocation']:
             modified_header.append(f"{self._flux_directive}" + "--exclusive")
 
@@ -322,7 +331,8 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         :returns: A string of the parallelize command configured using nodes
                   and procs.
         """
-        ntasks = nodes if nodes else self._batch.get("nodes", 1)
+        # nodes = nodes
+        # ntasks = nodes if nodes else self._batch.get("nodes", 1)
         
         # Handle the exclusive flags, updating batch block settings (default)
         # with what's set in the step, if any given
@@ -334,7 +344,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         kwargs['exclusive'] = step_exclusive['launcher']
 
         return self._interface.parallelize(
-            procs, nodes=ntasks, addtl_args=self._addl_args,
+            procs, nodes=nodes, addtl_args=self._addl_args,
             launcher_args=self._launcher_args, **kwargs)
 
     def submit(self, step, path, cwd, job_map=None, env=None):
@@ -350,14 +360,18 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         :returns: The return status of the submission command and job
                   identiifer.
         """
-        nodes = step.run.get("nodes", 1)
-        processors = step.run.get("procs", 0)
+        nodes = step.run.get("nodes", None)
+        processors = step.run.get("procs", 1)
 
-        if not isinstance(nodes, int):
-            if not nodes:
-                nodes = 1
-            else:
-                nodes = int(nodes)
+        if nodes == '':
+            nodes = None
+        if nodes is not None and nodes != '':  # Have to account for empty string!
+            nodes = int(nodes)
+        # if not isinstance(nodes, int):
+        #     if not nodes:
+        #         nodes = 1
+        #     else:
+        #         nodes = int(nodes)
 
         if not isinstance(processors, int):
             if not processors:
@@ -394,7 +408,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             raise val_error
 
         # Calculate nprocs
-        ncores = cores_per_task * nodes
+        ncores = cores_per_task * processors  # What was this check doing?
         # Raise an exception if ncores is 0
         if ncores <= 0:
             msg = "Invalid number of cores specified. " \

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -95,7 +95,6 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
 
         # NOTE: Host doesn"t seem to matter for FLUX. sbatch assumes that the
         # current host is where submission occurs.
-        # self.add_batch_parameter("nodes", kwargs.pop("nodes", "1"))
         self._allocation_args = kwargs.get("allocation_args", {})
         LOGGER.info(f"Allocation args: {self._allocation_args}")
         self._launcher_args = kwargs.get("launcher_args", {})
@@ -270,9 +269,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         step_exclusive = self.resolve_exclusive(self._exclusive, step_exclusive)
 
         nodes = run.get("nodes", None)
-        LOGGER.info("Retrived 'nodes' from the step: '%s'", nodes)
-        print(f"INFO: retrieved 'nodes' from step: '{nodes}'")
-        if nodes is not None and nodes != '':  # catch nodes = 0 here?
+        if nodes and nodes is not None and nodes != '':
             batch_header["nodes"] = run.pop("nodes")
 
         # Abusing 'truthiness' here to catch '' values too
@@ -331,9 +328,6 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         :returns: A string of the parallelize command configured using nodes
                   and procs.
         """
-        # nodes = nodes
-        # ntasks = nodes if nodes else self._batch.get("nodes", 1)
-        
         # Handle the exclusive flags, updating batch block settings (default)
         # with what's set in the step, if any given
         step_exclusive = kwargs.pop("exclusive", None)
@@ -368,22 +362,23 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         step_exclusive = step.run.get("exclusive", None)
 
         step_exclusive = self.resolve_exclusive(self._exclusive, step_exclusive)
+
+        # TODO: track this down and normalize this upstream for all adapters
         if nodes == '':
             nodes = None
-        if nodes is not None and nodes != '':  # Have to account for empty string!
-            nodes = int(nodes)
-        # if not isinstance(nodes, int):
-        #     if not nodes:
-        #         nodes = 1
-        #     else:
-        #         nodes = int(nodes)
 
+        if nodes is not None and not isinstance(nodes, int):
+            nodes = int(nodes)
+
+        # TODO: revist this after tracking down '' behavior seen with nodes
         if not isinstance(processors, int):
             if not processors:
-                processors = 1
+                processors = 1  # python api requires >= 1 for procs/tasks
             else:
                 processors = int(processors)
 
+
+            
         force_broker = step.run.get("nested", True)
         walltime = \
             self._convert_walltime_to_seconds(step.run.get("walltime", 0))
@@ -398,7 +393,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             except:
                 cores_per_task = 1
         if not cores_per_task:
-            cores_per_task = 1 # max((1, ceil(processors / nodes)))
+            cores_per_task = 1  # flux python api defaults to 1
             LOGGER.warn(
                 "'cores per task' set to a non-value. Populating with a "
                 "sensible default. (cores per task = %d", cores_per_task)
@@ -408,6 +403,7 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             ngpus = step.run.get("gpus", "0")
             ngpus = int(ngpus) if ngpus else 0
         except ValueError as val_error:
+            # TODO: normalize this upstream for all adapters
             msg = f"Specified gpus '{ngpus}' is not a decimal value."
             LOGGER.error(msg)
             raise val_error

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -362,7 +362,12 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
         """
         nodes = step.run.get("nodes", None)
         processors = step.run.get("procs", 1)
+        
+        # Handle the exclusive flags, updating batch block settings (default)
+        # with what's set in the step, if any given
+        step_exclusive = step.run.get("exclusive", None)
 
+        step_exclusive = self.resolve_exclusive(self._exclusive, step_exclusive)
         if nodes == '':
             nodes = None
         if nodes is not None and nodes != '':  # Have to account for empty string!
@@ -416,11 +421,16 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
             LOGGER.error(msg)
             raise ValueError(msg)
 
-        # Handle the exclusive flags, updating batch block settings (default)
-        # with what's set in the step, if any given
-        step_exclusive = step.run.get("exclusive", None)
-
-        step_exclusive = self.resolve_exclusive(self._exclusive, step_exclusive)
+        # Modify jobspec if exclusive to exclude procs/cores/gpus keys
+        # TODO: sort out confusing mixing of per task specs here and jobspec
+        #       creation calls using per slot specs...
+        # TODO: refactor into shared resource modification between this and
+        #       write_script/parallelize
+        if nodes and step_exclusive['allocation']:
+            # Should we do this here or inside submit?
+            processors = nodes  # one slot per node
+            cores_per_task = 1  # cores per slot >= 1 in python api
+            # filter out ngpus_per_slot inside submit
 
         # Unpack waitable flag and pass it along if there: only pass it along if
         # it's in the step maybe, leaving each adapter to retain their defaults?

--- a/maestrowf/interfaces/script/fluxscriptadapter.py
+++ b/maestrowf/interfaces/script/fluxscriptadapter.py
@@ -448,9 +448,8 @@ class FluxScriptAdapter(SchedulerScriptAdapter):
                 nodes, processors, cores_per_task, path, cwd, walltime, ngpus,
                 job_name=step.name, force_broker=force_broker, urgency=urgency,
                 waitable=waitable, queue=queue, bank=bank,
-                addtl_batch_args=packed_alloc_args, #self.pack_addtl_batch_args(),
+                addtl_batch_args=packed_alloc_args,
                 exclusive=step_exclusive['allocation'],
-                
             )
 
         return SubmissionRecord(submit_status, retcode, jobid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "maestrowf"
-version = "1.1.12dev3"
+version = "1.1.12dev4"
 description = "A tool to easily orchestrate general computational workflows both locally and on supercomputers."
 license = "MIT License"
 classifiers = [

--- a/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.bye_world_GREETING.Hello.NAME.Pam.flux.sh.1
+++ b/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.bye_world_GREETING.Hello.NAME.Pam.flux.sh.1
@@ -2,7 +2,6 @@
 #MAESTRO-INFO (flux adapter version) 0.49.0
 #MAESTRO-INFO (flux version) 0.78.0
 #
-#flux: -N 1
 #flux: -n 1
 #flux: -t 60.0s
 #flux: -q pdebug
@@ -15,5 +14,5 @@
 #flux: --setopt=bar=42
 #flux: --conf=resource.rediscover=true
 
-flux run -n 1 -N 1 -c 1 --setopt=fastload echo "Bye, World!" > bye.txt
-flux run -n 1 -N 1 -c 1 --setopt=fastload sleep 1
+flux run -n 1 --setopt=fastload echo "Bye, World!" > bye.txt
+flux run -n 1 --setopt=fastload sleep 1

--- a/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.bye_world_GREETING.Hello.NAME.Pam.flux.sh.3
+++ b/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.bye_world_GREETING.Hello.NAME.Pam.flux.sh.3
@@ -3,7 +3,6 @@
 #MAESTRO-INFO (flux version) 0.78.0
 #
 #flux: -N 1
-#flux: -n 1
 #flux: -t 60.0s
 #flux: -q pdebug
 #flux: --bank=guests
@@ -16,5 +15,5 @@
 #flux: --setopt=bar=42
 #flux: --conf=resource.rediscover=true
 
-flux run -n 1 -N 1 -c 1 --setopt=fastload echo "Bye, World!" > bye.txt
-flux run -n 1 -N 1 -c 1 --setopt=fastload sleep 1
+flux run -N 1 -n 1 --setopt=fastload echo "Bye, World!" > bye.txt
+flux run -N 1 -n 1 --setopt=fastload sleep 1

--- a/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.bye_world_GREETING.Hello.NAME.Pam.flux.sh.4
+++ b/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.bye_world_GREETING.Hello.NAME.Pam.flux.sh.4
@@ -3,7 +3,6 @@
 #MAESTRO-INFO (flux version) 0.78.0
 #
 #flux: -N 1
-#flux: -n 1
 #flux: -t 60.0s
 #flux: -q pdebug
 #flux: --bank=guests
@@ -16,5 +15,5 @@
 #flux: --setopt=bar=42
 #flux: --conf=resource.rediscover=true
 
-flux run -n 1 -N 1 -c 1 --setopt=fastload echo "Bye, World!" > bye.txt
-flux run -n 1 -N 1 -c 1 --setopt=fastload sleep 1
+flux run -N 1 -n 1 --setopt=fastload echo "Bye, World!" > bye.txt
+flux run -N 1 -n 1 --setopt=fastload sleep 1

--- a/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.hello_world_GREETING.Hello.NAME.Pam.flux.sh.1
+++ b/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.hello_world_GREETING.Hello.NAME.Pam.flux.sh.1
@@ -3,7 +3,6 @@
 #MAESTRO-INFO (flux version) 0.78.0
 #
 #flux: -N 1
-#flux: -n 1
 #flux: -t 60.0s
 #flux: -q pdebug
 #flux: --bank=guests
@@ -16,5 +15,5 @@
 #flux: --setopt=bar=42
 #flux: --conf=resource.rediscover=true
 
-flux run -n 1 -N 1 -c 1 --setopt=fastload echo "Hello, Pam!" > Hello_Pam.txt
-flux run -n 1 -N 1 -c 1 --setopt=fastload sleep 1
+flux run -N 1 -n 1 --setopt=fastload echo "Hello, Pam!" > Hello_Pam.txt
+flux run -N 1 -n 1 --setopt=fastload sleep 1

--- a/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.hello_world_GREETING.Hello.NAME.Pam.flux.sh.3
+++ b/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.hello_world_GREETING.Hello.NAME.Pam.flux.sh.3
@@ -3,7 +3,6 @@
 #MAESTRO-INFO (flux version) 0.78.0
 #
 #flux: -N 1
-#flux: -n 1
 #flux: -t 60.0s
 #flux: -q pdebug
 #flux: --bank=guests
@@ -16,5 +15,5 @@
 #flux: --setopt=bar=42
 #flux: --conf=resource.rediscover=true
 
-flux run -n 1 -N 1 -c 1 --exclusive --setopt=fastload echo "Hello, Pam!" > Hello_Pam.txt
-flux run -n 1 -N 1 -c 1 --exclusive --setopt=fastload sleep 1
+flux run -N 1 -n 1 --exclusive --setopt=fastload echo "Hello, Pam!" > Hello_Pam.txt
+flux run -N 1 -n 1 --exclusive --setopt=fastload sleep 1

--- a/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.hello_world_GREETING.Hello.NAME.Pam.flux.sh.4
+++ b/tests/data/expected_spec_outputs/hello_bye_parameterized_flux.hello_world_GREETING.Hello.NAME.Pam.flux.sh.4
@@ -3,7 +3,6 @@
 #MAESTRO-INFO (flux version) 0.78.0
 #
 #flux: -N 1
-#flux: -n 1
 #flux: -t 60.0s
 #flux: -q pdebug
 #flux: --bank=guests
@@ -16,5 +15,5 @@
 #flux: --setopt=bar=42
 #flux: --conf=resource.rediscover=true
 
-flux run -n 1 -N 1 -c 1 --exclusive --setopt=fastload echo "Hello, Pam!" > Hello_Pam.txt
-flux run -n 1 -N 1 -c 1 --exclusive --setopt=fastload sleep 1
+flux run -N 1 -n 1 --exclusive --setopt=fastload echo "Hello, Pam!" > Hello_Pam.txt
+flux run -N 1 -n 1 --exclusive --setopt=fastload sleep 1

--- a/tests/data/specs/hello_bye_parameterized_flux_1.yaml
+++ b/tests/data/specs/hello_bye_parameterized_flux_1.yaml
@@ -37,6 +37,7 @@ study:
           cmd: |
             $(LAUNCHER) echo "$(GREETING), $(NAME)!" > $(OUT_FORMAT)
             $(LAUNCHER) sleep 1
+          nodes: 1
           procs: 1
           nested: True
           exclusive: True

--- a/tests/data/specs/hello_bye_parameterized_flux_2.yaml
+++ b/tests/data/specs/hello_bye_parameterized_flux_2.yaml
@@ -16,12 +16,12 @@ batch:
         gpumode: CPX
       conf:
         resource:
-          rediscover: True # Flux wants 'true', not 'True' that python bool serializes to
+          rediscover: True
           noverify: True
         
     launcher_args:
       setopt:
-        fastload:
+        fastload: 
 
 
         

--- a/tests/data/specs/hello_bye_parameterized_flux_2.yaml
+++ b/tests/data/specs/hello_bye_parameterized_flux_2.yaml
@@ -38,6 +38,7 @@ study:
           cmd: |
             $(LAUNCHER) echo "$(GREETING), $(NAME)!" > $(OUT_FORMAT)
             $(LAUNCHER) sleep 1
+          nodes: 1              # Required for exclusive!
           procs: 1
           nested: True
           exclusive: True
@@ -55,12 +56,6 @@ study:
           depends: [hello_world]
 
 global.parameters:
-    # NAME:
-    #     values: [Pam, Jim, Michael, Dwight]
-    #     label: NAME.%%
-    # GREETING:
-    #     values: [Hello, Ciao, Hey, Hi]
-    #     label: GREETING.%%
     NAME:
         values: [Pam]
         label: NAME.%%

--- a/tests/data/specs/hello_bye_parameterized_flux_3.yaml
+++ b/tests/data/specs/hello_bye_parameterized_flux_3.yaml
@@ -16,7 +16,7 @@ batch:
         gpumode: CPX
       conf:
         resource:
-          rediscover: "true" # Flux wants 'true', not 'True' that python bool serializes to
+          rediscover: "true" 
         
     launcher_args:
       setopt:
@@ -38,6 +38,7 @@ study:
           cmd: |
             $(LAUNCHER) echo "$(GREETING), $(NAME)!" > $(OUT_FORMAT)
             $(LAUNCHER) sleep 1
+          nodes: 1
           procs: 1
           nested: True
           exclusive: True       # Testing mixed batch/step
@@ -49,6 +50,7 @@ study:
           cmd: |
             $(LAUNCHER) echo "Bye, World!" > bye.txt
             $(LAUNCHER) sleep 1
+          nodes: 1
           procs: 1
           nested: True
           exclusive:         # Test overriding launcher from batch block

--- a/tests/data/specs/hello_bye_parameterized_flux_4.yaml
+++ b/tests/data/specs/hello_bye_parameterized_flux_4.yaml
@@ -40,6 +40,7 @@ study:
           cmd: |
             $(LAUNCHER) echo "$(GREETING), $(NAME)!" > $(OUT_FORMAT)
             $(LAUNCHER) sleep 1
+          nodes: 1
           procs: 1
           nested: True
           exclusive: True       # Testing mixed batch/step
@@ -51,6 +52,7 @@ study:
           cmd: |
             $(LAUNCHER) echo "Bye, World!" > bye.txt
             $(LAUNCHER) sleep 1
+          nodes: 1
           procs: 1
           nested: True
           exclusive:         # Test overriding launcher from batch block

--- a/tests/data/specs/hello_flux_exclusive_1.yaml
+++ b/tests/data/specs/hello_flux_exclusive_1.yaml
@@ -1,0 +1,34 @@
+description:
+    name: hello_flux_exclusive_1.yaml
+    description: Test jobspec's resource/slot configs when running exclusive
+
+batch:
+    type        : flux
+    host        : rzadams
+    bank        : guests
+    queue       : pdebug
+        
+env:
+    variables:
+        OUTPUT_PATH: hello_flux_exclusive
+
+study:
+    - name: hello
+      description: Say hello, in parallel!
+      run:
+          cmd: |
+            $(LAUNCHER) echo "HELLO!"
+
+          nodes: $(NODES)
+          procs: $(PROCS)
+          exclusive: True
+          walltime: "00:30"
+
+global.parameters:
+  NODES:
+    values: [1, 1, 2, 2]
+    label: NODES.%%
+
+  PROCS:
+    values: [1, 2, 2, 1]              # Must be >= Nodes!
+    label: PROCS.%%

--- a/tests/interfaces/script/test_fluxscriptadapter.py
+++ b/tests/interfaces/script/test_fluxscriptadapter.py
@@ -140,21 +140,14 @@ def test_flux_script_serialization(
         pprint(f"Step name: {step_name}")
         ex_graph._execute_record(step_record, adapter)
 
-        # pprint(step_name)
-        # pprint("Step record:")
-        # pprint(step_record)
-        # # pprint(_record)
-        # pprint("Written script:")
         with open(step_record.script, "r") as written_script_file:
             written_script = written_script_file.read()
-            # pprint(written_script.splitlines())
 
         assert step_name in expected_batch_files
 
         with open(variant_expected_output(expected_batch_files[step_name]), 'r') as ebf:
             expected_script = ebf.read()
 
-        # assert written_script == expected_script
         assert text_diff(written_script, expected_script, ignore_patterns=ignore_patterns)
 
 

--- a/tests/interfaces/script/test_fluxscriptadapter.py
+++ b/tests/interfaces/script/test_fluxscriptadapter.py
@@ -267,3 +267,226 @@ def test_flux_job_opts(
                                        "attributes.system.files.script",  # Attached to cmd in python?
                                    },
                                    debug=False)
+
+
+
+@pytest.mark.sched_flux         # This one needs to at least import flux to work
+@pytest.mark.parametrize(
+    "spec_file, variant_id, expected_jobspec_keys, ignore_jobspec_keys",
+    [
+        (
+            "hello_flux_exclusive",
+            1,
+            {
+                "hello_NODES.1.PROCS.1": {
+                    'resources': [
+                        {
+                            "type": "node",
+                            "count": 1,
+                            "exclusive": True,
+                            "with": [
+                                {
+                                    "type": "slot",
+                                    "count": 1,
+                                    "with": [
+                                        {
+                                            "type": "core",
+                                            "count": 1
+                                        }
+                                    ],
+                                    "label": "task"
+                                }
+                            ]
+                        }
+                    ],
+                    'attributes': {
+                        'system': {
+                            'queue': 'pdebug',
+                            'bank': 'guests',
+                        }
+                    }
+                },
+                "hello_NODES.1.PROCS.2": {
+                    'resources': [
+                        {
+                            "type": "node",
+                            "count": 1,
+                            "exclusive": True,
+                            "with": [
+                                {
+                                    "type": "slot",
+                                    "count": 1,  # NOTE: EXCLUSIVE SHOULD FORCE THIS TO 1 NOT 2
+                                    "with": [
+                                        {
+                                            "type": "core",
+                                            "count": 1
+                                        }
+                                    ],
+                                    "label": "task"
+                                }
+                            ]
+                        }
+                    ],
+                    'attributes': {
+                        'system': {
+                            'queue': 'pdebug',
+                            'bank': 'guests',
+                        }
+                    }
+                },
+                "hello_NODES.2.PROCS.2": {
+                    'resources': [
+                        {
+                            "type": "node",
+                            "count": 2,
+                            "exclusive": True,
+                            "with": [
+                                {
+                                    "type": "slot",
+                                    "count": 1,  # Slots per node!
+                                    "with": [
+                                        {
+                                            "type": "core",
+                                            "count": 1
+                                        }
+                                    ],
+                                    "label": "task"
+                                }
+                            ]
+                        }
+                    ],
+                    'attributes': {
+                        'system': {
+                            'queue': 'pdebug',
+                            'bank': 'guests',
+                        }
+                    }
+                },
+                "hello_NODES.2.PROCS.1": {
+                    'resources': [
+                        {
+                            "type": "node",
+                            "count": 2,
+                            "exclusive": True,
+                            "with": [
+                                {
+                                    "type": "slot",
+                                    "count": 1,  # Flux adapter overrides this, 1 slot per node
+                                    "with": [
+                                        {
+                                            "type": "core",
+                                            "count": 1
+                                        }
+                                    ],
+                                    "label": "task"
+                                }
+                            ]
+                        }
+                    ],
+                    'attributes': {
+                        'system': {
+                            'queue': 'pdebug',
+                            'bank': 'guests',
+                        }
+                    }
+                },
+            },
+            {
+                "hello_NODES.1.PROCS.1": ["attributes.system.files"],
+                "hello_NODES.1.PROCS.2": ["attributes.system.files"],
+                "hello_NODES.2.PROCS.2": ["attributes.system.files"],
+                "hello_NODES.2.PROCS.1": ["attributes.system.files"],
+            }
+        ),
+    ]
+)
+def test_flux_resource_configs(
+        spec_file,
+        variant_id,
+        expected_jobspec_keys,
+        ignore_jobspec_keys,
+        variant_spec_path,
+        load_study,
+        flux_jobspec_check,
+        tmp_path,               # Pytest tmp dir fixture: Path()):
+        generate_jobspec_from_script,
+        capsys
+):
+    spec_path = variant_spec_path(spec_file + f"_{variant_id}.yaml")
+    pprint(spec_path)
+    yaml_spec = YAMLSpecification.load_specification(spec_path)  # Load this up to get the batch info
+
+    print(f"{tmp_path=}")
+    study: Study = load_study(spec_path, tmp_path, dry_run=False)
+    print(f"{study.output_path=}")
+    pkl_path: str
+    ex_graph: ExecutionGraph
+    pkl_path, ex_graph = study.stage()
+    ex_graph.set_adapter(yaml_spec.batch)
+
+    adapter = ScriptAdapterFactory.get_adapter(yaml_spec.batch["type"])
+    adapter = adapter(**ex_graph._adapter)
+
+    # Setup a diff ignore pattern to filter out the #INFO (flux version ...
+    ignore_patterns = [
+        re.compile(r'#MAESTRO-INFO \(flux version\)')
+    ]
+
+    # Loop over the steps and execute them
+    for step_name, step_record in ex_graph.values.items():
+        if step_name == "_source":
+            continue
+        
+        ex_graph._execute_record(step_record, adapter)
+        pprint("Step name:")
+        pprint(step_name)
+        pprint("Step record:")
+        pprint(step_record)
+
+        retcode, job_status = ex_graph.check_study_status()
+
+        pprint(f"{retcode=}, {job_status=}")
+        for record_name, status in job_status.items():
+            if step_name == record_name:
+                jobid = ex_graph.values[record_name].jobid[-1]
+
+                # Cancel the job; we just need jobspecs, not completion
+                c_record = adapter.cancel_jobs([jobid])
+
+
+                # Get the keys to ignore
+                step_ignore_keys = ignore_jobspec_keys[step_name]
+                direct_ignore_defaults = ["tasks.0.command.3"] # 
+                direct_ignore_keys = step_ignore_keys + direct_ignore_defaults
+
+                flux_jobspec_check(jobid,
+                                   expected_jobspec_keys[step_name],
+                                   source_label='mark.parametrized jobspec',
+                                   ignore_keys=set(direct_ignore_keys), #{"tasks.0.command.3"},
+                                   debug=False)
+
+                # Add a second test to ensure it matches written scripts' jobspec
+                script_jobspec = generate_jobspec_from_script(step_record.script)
+
+                script_ignore_defaults = ["tasks.0.command.3",  # script/cmd obtained via different methods between two modes
+                                          "attributes.system.environment",  # Not populated in 'base' jobspec from python, can't filter from batch --dry-run
+                                          # TURN OFF TEMPORARILY TO PATCH UP ASSERTION MESSAGE TRUNCATION
+                                          "attributes.system.cwd",  # Irrelevant difference
+                                          "attributes.system.shell.options.rlimit",  # Not populated via python?
+                                          "attributes.system.files.script"]  # Attached to cmd in python?
+
+                script_ignore_keys = script_ignore_defaults + step_ignore_keys
+
+                flux_jobspec_check(jobid,
+                                   script_jobspec,
+                                   source_label='script jobspec',
+                                   ignore_keys=set(script_ignore_keys),
+                                   # ignore_keys={
+                                   #     "tasks.0.command.3",  # script/cmd obtained via different methods between two modes
+                                   #     "attributes.system.environment",  # Not populated in 'base' jobspec from python, can't filter from batch --dry-run
+                                   #     # TURN OFF TEMPORARILY TO PATCH UP ASSERTION MESSAGE TRUNCATION
+                                   #     "attributes.system.cwd",  # Irrelevant difference
+                                   #     "attributes.system.shell.options.rlimit",  # Not populated via python?
+                                   #     "attributes.system.files.script",  # Attached to cmd in python?
+                                   # },
+                                   debug=False)

--- a/tests/interfaces/script/test_fluxscriptadapter.py
+++ b/tests/interfaces/script/test_fluxscriptadapter.py
@@ -202,7 +202,7 @@ def test_flux_job_opts(
         variant_spec_path,
         load_study,
         flux_jobspec_check,
-        tmp_path,               # Pytest tmp dir fixture: Path()):
+        tmp_path,               # Pytest tmp dir fixture: Path
         generate_jobspec_from_script,
 ):
     spec_path = variant_spec_path(spec_file + f"_{variant_id}.yaml")
@@ -408,7 +408,7 @@ def test_flux_resource_configs(
         variant_spec_path,
         load_study,
         flux_jobspec_check,
-        tmp_path,               # Pytest tmp dir fixture: Path()):
+        tmp_path,               # Pytest tmp dir fixture: Path
         generate_jobspec_from_script,
         capsys
 ):

--- a/tests/interfaces/script/test_fluxscriptadapter.py
+++ b/tests/interfaces/script/test_fluxscriptadapter.py
@@ -436,7 +436,7 @@ def test_flux_resource_configs(
     for step_name, step_record in ex_graph.values.items():
         if step_name == "_source":
             continue
-        
+
         ex_graph._execute_record(step_record, adapter)
         pprint("Step name:")
         pprint(step_name)
@@ -453,27 +453,30 @@ def test_flux_resource_configs(
                 # Cancel the job; we just need jobspecs, not completion
                 c_record = adapter.cancel_jobs([jobid])
 
-
                 # Get the keys to ignore
                 step_ignore_keys = ignore_jobspec_keys[step_name]
-                direct_ignore_defaults = ["tasks.0.command.3"] # 
+                direct_ignore_defaults = [
+                    "tasks.0.command.3"
+                ]
                 direct_ignore_keys = step_ignore_keys + direct_ignore_defaults
 
                 flux_jobspec_check(jobid,
                                    expected_jobspec_keys[step_name],
                                    source_label='mark.parametrized jobspec',
-                                   ignore_keys=set(direct_ignore_keys), #{"tasks.0.command.3"},
+                                   ignore_keys=set(direct_ignore_keys),
                                    debug=False)
 
                 # Add a second test to ensure it matches written scripts' jobspec
                 script_jobspec = generate_jobspec_from_script(step_record.script)
 
-                script_ignore_defaults = ["tasks.0.command.3",  # script/cmd obtained via different methods between two modes
-                                          "attributes.system.environment",  # Not populated in 'base' jobspec from python, can't filter from batch --dry-run
-                                          # TURN OFF TEMPORARILY TO PATCH UP ASSERTION MESSAGE TRUNCATION
-                                          "attributes.system.cwd",  # Irrelevant difference
-                                          "attributes.system.shell.options.rlimit",  # Not populated via python?
-                                          "attributes.system.files.script"]  # Attached to cmd in python?
+                script_ignore_defaults = [
+                    "tasks.0.command.3",  # script/cmd obtained via different methods between two modes
+                    "attributes.system.environment",  # Not populated in 'base' jobspec from python, can't filter from batch --dry-run
+                    # TURN OFF TEMPORARILY TO PATCH UP ASSERTION MESSAGE TRUNCATION
+                    "attributes.system.cwd",  # Irrelevant difference
+                    "attributes.system.shell.options.rlimit",  # Not populated via python?
+                    "attributes.system.files.script"  # Attached to cmd in python?
+                ]
 
                 script_ignore_keys = script_ignore_defaults + step_ignore_keys
 
@@ -481,12 +484,4 @@ def test_flux_resource_configs(
                                    script_jobspec,
                                    source_label='script jobspec',
                                    ignore_keys=set(script_ignore_keys),
-                                   # ignore_keys={
-                                   #     "tasks.0.command.3",  # script/cmd obtained via different methods between two modes
-                                   #     "attributes.system.environment",  # Not populated in 'base' jobspec from python, can't filter from batch --dry-run
-                                   #     # TURN OFF TEMPORARILY TO PATCH UP ASSERTION MESSAGE TRUNCATION
-                                   #     "attributes.system.cwd",  # Irrelevant difference
-                                   #     "attributes.system.shell.options.rlimit",  # Not populated via python?
-                                   #     "attributes.system.files.script",  # Attached to cmd in python?
-                                   # },
                                    debug=False)


### PR DESCRIPTION
Updates handling of exclusive keys to modify the batch directives and launcher rendering

* Prunes everything but nodes from allocations
* If set on launcher, overrides any cores per task, gpu flags, leaving nodes and tasks only
* Jobspec creation via Python api now sets num_slots = nodes when exclusive is set, matching flux behavior

Updates default renderings:
* cores per task omitted from launcher if not set in step keys
* removes default 'nodes=1' in batch header/directives to sync with step keys
* retains required >=1 for tasks/cores per task in jobspec creation but omits from rendered batch scripts to sync with flux default behaviors

Unblocks scheduling to nodes with configurable resources: subdividing gpus happens after allocation startup, and prior behavior of attaching tasks/gpus to allocation would cause flux to reject such jobs (unsatisfiable).