### PR TITLE
Match parameter tokens exactly in get_used_parameters

### DIFF
--- a/changelog.d/20260721_190000_arpitjain099_used_params_prefix_collision.md
+++ b/changelog.d/20260721_190000_arpitjain099_used_params_prefix_collision.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `get_used_parameters` no longer matches a parameter whose name is a prefix of another, so a step using only `$(NP)` is no longer reported as also using `$(N)`.  The token pattern now requires an exact name followed by an optional `.attribute`, and the name is escaped before it goes into the regex.  Implemented in [PR #478](https://github.com/llnl/maestrowf/pull/478).

--- a/maestrowf/datastructures/core/parameters.py
+++ b/maestrowf/datastructures/core/parameters.py
@@ -331,7 +331,7 @@ class ParameterGenerator:
             return
         elif isinstance(item, str):
             for key in self.parameters.keys():
-                _ = r"\{}\({}\.*\w*\)".format(self.token, key)
+                _ = r"\{}\({}(\.\w+)?\)".format(self.token, re.escape(key))
                 matches = re.findall(_, item)
                 if matches:
                     params.add(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "maestrowf"
-version = "1.2.1dev2"
+version = "1.2.1dev3"
 description = "A tool to easily orchestrate general computational workflows both locally and on supercomputers."
 license = "MIT License"
 classifiers = [

--- a/tests/test_used_parameters.py
+++ b/tests/test_used_parameters.py
@@ -1,0 +1,14 @@
+from maestrowf.datastructures.core.parameters import ParameterGenerator
+from maestrowf.datastructures.core.study import StudyStep
+
+
+def test_get_used_parameters_no_prefix_collision():
+    pgen = ParameterGenerator()
+    pgen.add_parameter("N", [1, 2], "N.%%")
+    pgen.add_parameter("NP", [4, 8], "NP.%%")
+
+    step = StudyStep()
+    step.run["cmd"] = "srun -n $(NP) ./solver"
+
+    # A step that only uses $(NP) must not also pull in $(N) via prefix match.
+    assert pgen.get_used_parameters(step) == {"NP"}


### PR DESCRIPTION
`_get_used_parameters` builds its search pattern as:

```python
_ = r"\{}\({}\.*\w*\)".format(self.token, key)
```

Here `\.*` is "zero or more literal dots" and `\w*` is "zero or more word characters", so after the parameter name it happily consumes more characters. For a parameter named `N` the pattern matches `$(NP)`, so a step whose command uses only `$(NP)` reports both `N` and `NP` as used:

```
get_used_parameters(step using only "$(NP)")  ->  {"N", "NP"}   # should be {"NP"}
```

`get_used_parameters` feeds `Study.get_tasks_per_step`, which uses the result to decide whether a step is expanded across parameter combinations and to build the combination workspace/label names. So a prefix collision (common in HPC specs: `N`/`NP`, `X`/`X2`, `SIZE`/`SIZE_B`) can attach the wrong parameters to a step, and a step whose command literally contains a `$(N...)`-shaped token can be expanded into extra instances.

Fix: require the character after the key to be `)` or `.<suffix>`, and `re.escape` the key:

```python
_ = r"\{}\({}(\.\w+)?\)".format(self.token, re.escape(key))
```

`$(key)`, `$(key.label)`, and `$(key.name)` still match; `$(NP)` no longer matches key `N`.

Added `tests/test_used_parameters.py`. I verified the fix directly under Python 3.13 (`$(NP)`-only step yields `{"NP"}`; the exact/`.label`/`.name` forms still resolve; the old pattern returns `{"N","NP"}`). Note: the full `pytest` suite does not collect on my machine because the repo's `conftest.py` applies a mark to a fixture, which pytest 8 rejects, unrelated to this change.
