### PR TITLE
Relax hypothesis test timings in CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,7 @@ Hotfixes on `main` are allowed in principle, but no formal hotfix workflow has b
 
 ## Changelog fragments
 
-This project uses `scriv` to manage changelog fragments.
-
-Fragments are stored in:
+This project uses `scriv` to manage changelog fragments.  `scriv` is installed with the project dependencies, and creating the fragment is as simple as `scrive create` from the top level and then edit that fragment. Fragments are stored in:
 
 - `changelog.d/`
 
@@ -76,7 +74,7 @@ Use one of the following categories in changelog fragments:
 | Fixed | Bug fixes |
 | Removed | Removed functionality |
 | Documentation | Important documentation changes |
-| Maintenance | Internal maintenance or dependency updates |
+| Maintenance | Internal maintenance or dependency updates, CI, tooling, ... |
 
 ## Changelog files
 

--- a/changelog.d/20260803_095149_jwhite242_hypothesis_test_stability.md
+++ b/changelog.d/20260803_095149_jwhite242_hypothesis_test_stability.md
@@ -1,4 +1,4 @@
 ### Maintenance
 
-- Creates ci profile for hypothesis enabled tests to account for increased system variability via extending deadlines
+- Creates ci profile for hypothesis enabled tests to account for increased system variability via extending deadlines.  Implemented in [PR #480](https://github.com/llnl/maestrowf/pull/480).
 

--- a/changelog.d/20260803_095149_jwhite242_hypothesis_test_stability.md
+++ b/changelog.d/20260803_095149_jwhite242_hypothesis_test_stability.md
@@ -1,0 +1,4 @@
+### Maintenance
+
+- Creates ci profile for hypothesis enabled tests to account for increased system variability via extending deadlines
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "maestrowf"
-version = "1.2.1dev3"
+version = "1.2.1dev4"
 description = "A tool to easily orchestrate general computational workflows both locally and on supercomputers."
 license = "MIT License"
 classifiers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,23 @@ from maestrowf.utils import (
 
 from packaging.version import InvalidVersion
 
+# Hypothesis profiles
+from hypothesis import settings
+
+#  Profile for local development using default deadlines
+settings.register_profile("local", deadline=200, max_examples=100)
+
+#  Profile for CI with relaxed deadlines to handle system variability
+settings.register_profile("ci", deadline=500, max_examples=100)
+
+#  Auto-detect and load correct profile
+if os.getenv("CI") == "true":
+    settings.load_profile("ci")
+else:
+    settings.load_profile("local")
+    
+
+# Check for active schedulers to enable/disable appropriate tests
 SCHEDULERS = set(('sched_lsf', 'sched_slurm', 'sched_flux', 'sched_local'))
 SCHED_CHECKS = defaultdict(lambda: False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ SCHED_CHECKS['sched_lsf'] = check_lsf
 
 def check_slurm():
     """
-    Checks if there is a slurm instance to schedule to. NOT IMPLEMENTED YET.
+    Checks if there is a slurm instance to schedule to.
     """
     slurm_info_func = 'sinfo'
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ from hypothesis import settings
 settings.register_profile("local", deadline=200, max_examples=100)
 
 #  Profile for CI with relaxed deadlines to handle system variability
-settings.register_profile("ci", deadline=500, max_examples=100)
+settings.register_profile("ci", deadline=1000, max_examples=100)
 
 #  Auto-detect and load correct profile
 if os.getenv("CI") == "true":


### PR DESCRIPTION
Adds local and ci profiles for hypothesis test cases.  Ci profile extends deadlines to handle higher system variability that was causing sporadic test failures due to default hypothesis deadline being exceeded.