### PR TITLE
Guard sleep in job submission loop to only trigger on failures

### DIFF
--- a/changelog.d/20260803_102412_jwhite242_submit_sleep.md
+++ b/changelog.d/20260803_102412_jwhite242_submit_sleep.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Guards sleep in submit loop to only trigger if a submission failure occurs.  Significantly speeds up job submission rates.

--- a/changelog.d/20260803_102412_jwhite242_submit_sleep.md
+++ b/changelog.d/20260803_102412_jwhite242_submit_sleep.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Guards sleep in submit loop to only trigger if a submission failure occurs.  Significantly speeds up job submission rates.
+- Guards sleep in submit loop to only trigger if a submission failure occurs.  Significantly speeds up job submission rates which were previously capped at 1 per second due to this sleep.  Implemented in [PR #481](https://github.com/llnl/maestrowf/pull/481).

--- a/maestrowf/datastructures/core/executiongraph.py
+++ b/maestrowf/datastructures/core/executiongraph.py
@@ -642,7 +642,8 @@ class ExecutionGraph(DAG, PickleInterface):
             # Increment the number of restarts we've attempted.
             LOGGER.debug("Completed submission attempt %d", num_restarts)
             num_restarts += 1
-            sleep((random.random() + 1) * num_restarts)
+            if retcode != SubmissionCode.OK:
+                sleep((random.random() + 1) * num_restarts)
 
         if retcode == SubmissionCode.OK:
             self.in_progress.add(record.name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "maestrowf"
-version = "1.2.1dev3"
+version = "1.2.1dev5"
 description = "A tool to easily orchestrate general computational workflows both locally and on supercomputers."
 license = "MIT License"
 classifiers = [


### PR DESCRIPTION
Fixes job submission loop to only trigger a sleep if a job submission error occurs instead of after every submission.  Significantly speeds up job submission rates which were previously capped at ~1 per second due to this sleep.